### PR TITLE
simplifies PointerLockControls.getDirection()

### DIFF
--- a/src/controls/PointerLockControls.ts
+++ b/src/controls/PointerLockControls.ts
@@ -32,10 +32,6 @@ class PointerLockControls extends EventDispatcher {
     this.domElement = domElement
     this.camera = camera
 
-    //
-    // internals
-    //
-
     this.connect()
   }
 
@@ -93,11 +89,8 @@ class PointerLockControls extends EventDispatcher {
     // retaining this method for backward compatibility
     this.camera
 
-  getDirection = (() => {
-    const direction = new Vector3(0, 0, -1)
-
-    return (v: Vector3) => v.copy(direction).applyQuaternion(this.camera.quaternion)
-  })()
+  private direction = new Vector3(0, 0, -1)
+  getDirection = (v: Vector3) => v.copy(this.direction).applyQuaternion(this.camera.quaternion)
 
   moveForward = (distance: number) => {
     // move forward parallel to the xz-plane


### PR DESCRIPTION
### What

<!-- what have you done, if its a bug, whats your solution? -->

moves `direction: Vector3` out from `getDirection()` to be a private prop + removes what looked like a now unnecessary comment 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->
 
- [x ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
