### PR TITLE
Add no-var eslint rule to enforce code style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "import/default": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "no-unused-vars": ["warn"],
+    "no-var": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -282,13 +282,13 @@ class OrbitControls extends EventDispatcher {
     // internals
     //
 
-    var scope = this
+    const scope = this
 
-    var changeEvent = { type: 'change' }
+    const changeEvent = { type: 'change' }
     const startEvent = { type: 'start' }
     const endEvent = { type: 'end' }
 
-    var STATE = {
+    const STATE = {
       NONE: -1,
       ROTATE: 0,
       DOLLY: 1,
@@ -299,17 +299,17 @@ class OrbitControls extends EventDispatcher {
       TOUCH_DOLLY_ROTATE: 6,
     }
 
-    var state = STATE.NONE
+    let state = STATE.NONE
 
-    var EPS = 0.000001
+    const EPS = 0.000001
 
     // current position in spherical coordinates
-    var spherical = new Spherical()
-    var sphericalDelta = new Spherical()
+    const spherical = new Spherical()
+    const sphericalDelta = new Spherical()
 
-    var scale = 1
-    var panOffset = new Vector3()
-    var zoomChanged = false
+    let scale = 1
+    const panOffset = new Vector3()
+    let zoomChanged = false
 
     const rotateStart = new Vector2()
     const rotateEnd = new Vector2()


### PR DESCRIPTION
Fix existing errors in OrbitControls file

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

This was done as a follow-up to some peer feedback in another PR of mine (https://github.com/pmndrs/three-stdlib/pull/32#discussion_r593970348), and I figured it would be easier to enforce this at the lint level instead, just in case other contributors did something similar when copy-pasting existing examples.


### Checklist


- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
