### PR TITLE
Add babel-runtime as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,8 @@
     "@babel/core": "^7.13.10",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-proposal-optional-chaining": "^7.13.8",
-    "@babel/plugin-transform-modules-commonjs": "^7.13.8",
     "@babel/plugin-transform-parameters": "^7.13.0",
     "@babel/plugin-transform-runtime": "^7.13.10",
-    "@babel/plugin-transform-template-literals": "^7.13.0",
     "@babel/preset-env": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
     "@rollup/plugin-typescript": "^8.2.0",
@@ -95,6 +93,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.13.10",
     "@webgpu/glslang": "^0.0.15",
     "@webxr-input-profiles/motion-controllers": "^1.0.0",
     "chevrotain": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,6 +1133,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.12.7":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Clearly states if you use the `transform` plugin, you need to add `@babel/runtime` as a dependency. It was probably latching onto deps of other modules that do have it, see here: https://babeljs.io/docs/en/babel-plugin-transform-runtime#installation

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
