### PR TITLE
Copy @three/types/examples at build time

### DIFF
--- a/.storybook/stories/TransformControls.stories.ts
+++ b/.storybook/stories/TransformControls.stories.ts
@@ -3,8 +3,7 @@ import { useEffect } from '@storybook/client-api'
 
 import { useThree } from '../setup'
 
-//@ts-ignore
-import { TransformControls, OrbitControls } from '../../src'
+import { TransformControls } from '../../src'
 
 export default {
   title: 'Controls/Transform',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.cjs.js",
   "module": "index.js",
   "scripts": {
-    "build": "rollup -c && npm run copy",
+    "build": "rollup -c && node ./scripts/createDeclarations.js",
     "build-storybook": "build-storybook -s ./.storybook/public",
     "copy": "copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\"",
     "lint": "eslint --cache --fix src/**/*.ts",
@@ -78,6 +78,7 @@
     "json": "^10.0.0",
     "lint-staged": "^10.2.11",
     "prettier": "^2.2.1",
+    "recrawl": "^2.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
     "rollup-plugin-babel": "^4.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default [
     ],
   },
   {
-    input: `./src/index.js`,
+    input: `./src/index.ts`,
     output: { dir: `dist`, format: 'esm' },
     external,
     plugins: [
@@ -60,7 +60,7 @@ export default [
     ],
   },
   {
-    input: `./src/index.js`,
+    input: `./src/index.ts`,
     output: { file: `dist/index.cjs.js`, format: 'cjs' },
     external,
     plugins: [json(), babel(getBabelOptions({ useESModules: false })), resolve({ extensions }), terser()],

--- a/scripts/createDeclarations.js
+++ b/scripts/createDeclarations.js
@@ -1,0 +1,46 @@
+const fs = require('fs')
+const { recrawl } = require('recrawl')
+
+const THREE_TYPES_ROOT = 'node_modules/@types/three'
+const STDLIB_BUILD_ROOT = 'dist'
+
+const crawl = recrawl({
+  // only look at the .js files
+  skip: ['*.cjs.js', '*.d.ts'],
+})
+
+crawl(STDLIB_BUILD_ROOT, (file) => {
+  // remove extension
+  const fileName = file.split('.js')[0]
+
+  const localFile = `${STDLIB_BUILD_ROOT}/${fileName}.d.ts`
+  const externalFile = `${THREE_TYPES_ROOT}/examples/jsm/${fileName}.d.ts`
+
+  // check if there's a local .d.ts file created
+  const doesLocalDeclarationExist = fs.existsSync(localFile)
+  // check if there's a @types/three .d.ts file created
+  const doesExternalDeclarationExist = fs.existsSync(externalFile)
+
+  // if theres no local but a @types/three file
+  if (!doesLocalDeclarationExist && doesExternalDeclarationExist) {
+    // copy it
+    fs.copyFileSync(externalFile, localFile)
+    console.log(`copied ${fileName}.d.ts from @types/three`)
+
+    // read the new local file for editing
+    fs.readFile(localFile, 'utf8', (err, data) => {
+      if (err) throw err
+      // this will capture any number of ../ and then src/Three
+      var result = data.replace(/[\.\.\/]*src\/Three/, 'three')
+
+      // edit the relative path in .d.ts file
+      fs.writeFile(localFile, result, 'utf8', (err) => {
+        if (err) throw err
+      })
+    })
+  } else if (doesLocalDeclarationExist) {
+    console.log('local declaration file exists')
+  } else {
+    console.warn('No local or external declaration file exists')
+  }
+})

--- a/src/controls/TransformControls.ts
+++ b/src/controls/TransformControls.ts
@@ -23,6 +23,7 @@ import {
   Intersection,
   TorusGeometry,
   Vector3,
+  Camera,
 } from 'three'
 
 export interface TransformControlsPointerObject {
@@ -31,7 +32,7 @@ export interface TransformControlsPointerObject {
   button: number
 }
 
-class TransformControls extends Object3D {
+class TransformControls<TCamera extends Camera = Camera> extends Object3D {
   public readonly isTransformControls = true
 
   public visible = false
@@ -84,7 +85,7 @@ class TransformControls extends Object3D {
   private _quaternionStart = new Quaternion()
   private _scaleStart = new Vector3()
 
-  private _camera: PerspectiveCamera | OrthographicCamera
+  private _camera: TCamera
   private _object: Object3D | undefined
   private _enabled = true
   private _axis: string | null = null
@@ -105,7 +106,7 @@ class TransformControls extends Object3D {
   private mouseUpEvent = { type: 'mouseUp', mode: this._mode }
   private objectChangeEvent = { type: 'objectChange' }
 
-  constructor(camera: PerspectiveCamera | OrthographicCamera, domElement: HTMLElement) {
+  constructor(camera: TCamera, domElement: HTMLElement) {
     super()
 
     if (domElement === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/export */
+// @ts-nocheck
 export * from './libs/meshopt_decoder'
 export * from './offscreen/scene'
 export * from './offscreen/offscreen'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,6 +1193,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cush/relative@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@cush/relative/-/relative-0.1.0.tgz#19bfc2c8d46335205932f2032e3569f99fd61b40"
+  integrity sha512-pnF2c2hhHyC520CmYYKq3hGOS0kipkGBgRnp3z7wx7lDzykaUwQW3wPQmiX9YtbHUcgUu1qQtzstixmeYMwQoA==
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -5734,6 +5739,11 @@ glob-promise@^3.4.0:
   dependencies:
     "@types/glob" "*"
 
+glob-regex@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/glob-regex/-/glob-regex-0.3.2.tgz#27348f2f60648ec32a4a53137090b9fb934f3425"
+  integrity sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -9058,6 +9068,15 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+recrawl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/recrawl/-/recrawl-2.0.0.tgz#bb2e4d5424435d2a2ac15a61a84f21510d087fec"
+  integrity sha512-PmL1uxEDduB/qqWc06KZzGJ4j//sXAuMlTcNJFFAEMTffJIFrzFghOxkgHU8+auKOUILEdbyfuEvFyoeu4mJgQ==
+  dependencies:
+    "@cush/relative" "^0.1.0"
+    glob-regex "^0.3.0"
+    tslib "^1.9.3"
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
@@ -10447,7 +10466,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
only copies files that exist if we don't already have the file

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Free .d.ts files while we move everything over!

### What

<!-- what have you done, if its a bug, whats your solution? --> 

runs a small script in node after build to find out which `.d.ts` files are missing and copy them over from `@types/three`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
