### PR TITLE
Make MapControls domElement parameter optional

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -910,7 +910,7 @@ class OrbitControls extends EventDispatcher {
 //    Pan - left mouse, or arrow keys / touch: one-finger move
 
 class MapControls extends OrbitControls {
-  constructor(object: Camera, domElement: HTMLElement) {
+  constructor(object: Camera, domElement?: HTMLElement) {
     super(object, domElement)
 
     this.screenSpacePanning = false // pan orthogonal to world-space direction camera.up


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

This should be the only change needed in `three-stdlib` to close https://github.com/pmndrs/three-stdlib/issues/47. I'm following with another change in drei.

We don't want to pass domElement to MapControls as it causes a side effect — connects handlers to DOM.
This seems to be just a TypeScript adoption mishap, as OrbitControls's domElement parameter is correctly optional.

### What

Made domElement constructor parameter optional.

### Checklist

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
