### PR TITLE
chore: remove deprecated keyCode in controls

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -62,7 +62,7 @@ class OrbitControls extends EventDispatcher {
   autoRotate = false
   autoRotateSpeed = 2.0 // 30 seconds per orbit when fps is 60
   // The four arrow keys
-  keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 }
+  keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' }
   // Mouse buttons
   mouseButtons = {
     LEFT: MOUSE.ROTATE,
@@ -498,7 +498,7 @@ class OrbitControls extends EventDispatcher {
     function handleKeyDown(event: KeyboardEvent) {
       let needsUpdate = false
 
-      switch (event.keyCode) {
+      switch (event.code) {
         case scope.keys.UP:
           pan(0, scope.keyPanSpeed)
           needsUpdate = true

--- a/src/controls/TrackballControls.ts
+++ b/src/controls/TrackballControls.ts
@@ -19,7 +19,7 @@ class TrackballControls extends EventDispatcher {
   public minDistance = 0
   public maxDistance = Infinity
 
-  public keys: [number, number, number] = [65 /*A*/, 83 /*S*/, 68 /*D*/]
+  public keys: [string, string, string] = ['KeyA' /*A*/, 'KeyS' /*S*/, 'KeyD' /*D*/]
 
   public mouseButtons = {
     LEFT: MOUSE.ROTATE,
@@ -344,11 +344,11 @@ class TrackballControls extends EventDispatcher {
 
     if (this._keyState !== this.STATE.NONE) {
       return
-    } else if (event.keyCode === this.keys[this.STATE.ROTATE] && !this.noRotate) {
+    } else if (event.code === this.keys[this.STATE.ROTATE] && !this.noRotate) {
       this._keyState = this.STATE.ROTATE
-    } else if (event.keyCode === this.keys[this.STATE.ZOOM] && !this.noZoom) {
+    } else if (event.code === this.keys[this.STATE.ZOOM] && !this.noZoom) {
       this._keyState = this.STATE.ZOOM
-    } else if (event.keyCode === this.keys[this.STATE.PAN] && !this.noPan) {
+    } else if (event.code === this.keys[this.STATE.PAN] && !this.noPan) {
       this._keyState = this.STATE.PAN
     }
   }

--- a/src/controls/experimental/CameraControls.ts
+++ b/src/controls/experimental/CameraControls.ts
@@ -95,7 +95,7 @@ class CameraControls extends EventDispatcher {
   enableKeys = true
 
   /** The four arrow keys */
-  keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 }
+  keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' }
 
   mouseButtons: {
     LEFT: MOUSE
@@ -545,8 +545,7 @@ class CameraControls extends EventDispatcher {
   private handleKeyDown = (event: KeyboardEvent): void => {
     let needsUpdate = false
 
-    // TODO: keyCode deprecated?
-    switch (event.keyCode) {
+    switch (event.code) {
       case this.keys.UP:
         this.pan(0, this.keyPanSpeed)
         needsUpdate = true


### PR DESCRIPTION
Brings the controls here in three-stdlib closer up to date with three: https://github.com/mrdoob/three.js/pull/21409

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
