### PR TITLE
fix: #60 update transform controls axes visual feedback to match threejs

### DIFF
--- a/.storybook/stories/TransformControls.stories.ts
+++ b/.storybook/stories/TransformControls.stories.ts
@@ -25,10 +25,10 @@ export const Default = () => {
 
     const mesh = new Mesh(geometry, material)
     scene.add(mesh)
-
     control.attach(mesh)
     scene.add(control)
-
+    camera.position.set(0,1.5,-4)
+    camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
     return () => {
@@ -38,3 +38,71 @@ export const Default = () => {
 
   return ''
 }
+Default.storyName = 'Translate'
+
+export const RotateStory = () => {
+  // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
+  useEffect(() => {
+    const { renderer, scene, camera, render } = useThree({
+      orbit: false,
+      //   useFrame: (_, delta) => {},
+    })
+
+    const geometry = new BoxGeometry(2, 2)
+    const material = new MeshBasicMaterial({ wireframe: true })
+
+    const control = new TransformControls(camera, renderer.domElement)
+    control.addEventListener('change', render)
+
+    const mesh = new Mesh(geometry, material)
+    scene.add(mesh)
+    control.attach(mesh)
+    control.setMode('rotate')
+    scene.add(control)
+    camera.position.set(0,1.5,-4)
+    camera.lookAt(mesh.position)
+    scene.background = new Color(0x000000).convertSRGBToLinear()
+
+    return () => {
+      renderer.dispose()
+    }
+  }, [])
+
+  return ''
+}
+RotateStory.storyName = 'Rotate'
+
+export const ScaleStory = () => {
+  // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
+  useEffect(() => {
+    const { renderer, scene, camera, render } = useThree({
+      orbit: false,
+      //   useFrame: (_, delta) => {},
+    })
+
+    const geometry = new BoxGeometry(2, 2)
+    const material = new MeshBasicMaterial({ wireframe: true })
+
+    const control = new TransformControls(camera, renderer.domElement)
+    control.addEventListener('change', render)
+
+    const mesh = new Mesh(geometry, material)
+    scene.add(mesh)
+
+    control.attach(mesh)
+    control.setMode('scale')
+    scene.add(control)
+    camera.position.set(0,1.5,-4)
+    camera.lookAt(mesh.position)
+    scene.background = new Color(0x000000).convertSRGBToLinear()
+
+    return () => {
+      renderer.dispose()
+    }
+  }, [])
+
+  return ''
+}
+ScaleStory.storyName = 'Scale'
+
+

--- a/.storybook/stories/TransformControls.stories.ts
+++ b/.storybook/stories/TransformControls.stories.ts
@@ -27,7 +27,7 @@ export const Default = () => {
     scene.add(mesh)
     control.attach(mesh)
     scene.add(control)
-    camera.position.set(0,1.5,-4)
+    camera.position.set(0, 1.5, -4)
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
@@ -59,7 +59,7 @@ export const RotateStory = () => {
     control.attach(mesh)
     control.setMode('rotate')
     scene.add(control)
-    camera.position.set(0,1.5,-4)
+    camera.position.set(0, 1.5, -4)
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
@@ -92,7 +92,7 @@ export const ScaleStory = () => {
     control.attach(mesh)
     control.setMode('scale')
     scene.add(control)
-    camera.position.set(0,1.5,-4)
+    camera.position.set(0, 1.5, -4)
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
@@ -104,5 +104,3 @@ export const ScaleStory = () => {
   return ''
 }
 ScaleStory.storyName = 'Scale'
-
-

--- a/src/controls/TransformControls.ts
+++ b/src/controls/TransformControls.ts
@@ -1271,13 +1271,13 @@ class TransformControlsGizmo extends Object3D {
       // highlight selected axis
 
       //@ts-ignore
-      handle.material.opacity = handle.material.opacity || handle.material.opacity
+      handle.material.tempOpacity = handle.material.tempOpacity || handle.material.opacity
       //@ts-ignore
-      handle.material.color = handle.material.color || handle.material.color.clone()
+      handle.material.tempColor = handle.material.tempColor || handle.material.color.clone()
       //@ts-ignore
-      handle.material.color.copy(handle.material.color)
+      handle.material.color.copy(handle.material.tempColor)
       //@ts-ignore
-      handle.material.opacity = handle.material.opacity
+      handle.material.opacity = handle.material.tempOpacity
 
       if (!this.enabled) {
         //@ts-ignore


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Fixing issue [60#](https://github.com/pmndrs/three-stdlib/issues/60) 

### What

<!-- what have you done, if its a bug, whats your solution? -->

As per the code of the original three js the visual feedback on the axes is managed simply by creating a couple of temporary variable for the colour and opacity.  See here :
https://github.com/mrdoob/three.js/blob/d39d82999f0ac5cdd1b4eb9f4aba3f9626f32ab6/examples/jsm/controls/TransformControls.js#L1528-L1532
The `_opacity` and `_color` are simply temp variable that suffered from a refactoring error in [this commit](https://github.com/pmndrs/three-stdlib/commit/cc079be1d2bb5f619202341a2fa53a4cb006056c)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
