### PR TITLE
Automatic enabling of USE_DASH define in lines

### DIFF
--- a/.storybook/stories/Line.stories.ts
+++ b/.storybook/stories/Line.stories.ts
@@ -6,11 +6,11 @@ import { useThree } from '../setup'
 //@ts-ignore
 import { hilbert3D, Line2, LineMaterial, LineGeometry } from '../../src'
 
-export default {
-  title: 'Geometry/Line',
+type TemplateProps = {
+  dashed: boolean
 }
 
-export const Default = () => {
+const Template = (props: TemplateProps) => {
   // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
   useEffect(() => {
     const { scene, renderer } = useThree()
@@ -48,7 +48,7 @@ export const Default = () => {
       linewidth: 5, // in pixels
       vertexColors: true,
       resolution: new Vector2(window.innerWidth, window.innerHeight),
-      dashed: false,
+      dashed: props.dashed,
     })
 
     const line = new Line2(geometry, matLine)
@@ -60,7 +60,22 @@ export const Default = () => {
     return () => {
       renderer.dispose()
     }
-  }, [])
+  }, [props.dashed])
 
   return ''
+}
+
+export const Default = Template.bind({})
+
+export default {
+  title: 'Geometry/Line',
+  argTypes: {
+    dashed: {
+      name: 'dashed',
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
+  },
 }

--- a/demos/ssr/components/Line.tsx
+++ b/demos/ssr/components/Line.tsx
@@ -40,16 +40,6 @@ export const Line = React.forwardRef<Line2, LineProps>(function Line(
     line2.computeLineDistances()
   }, [points, line2])
 
-  React.useLayoutEffect(() => {
-    if (dashed) {
-      lineMaterial.defines.USE_DASH = ''
-    } else {
-      // Setting lineMaterial.defines.USE_DASH to undefined is apparently not sufficient.
-      delete lineMaterial.defines.USE_DASH
-    }
-    lineMaterial.needsUpdate = true
-  }, [dashed, lineMaterial])
-
   return (
     <primitive dispose={undefined} object={line2} ref={ref} {...rest}>
       <primitive dispose={undefined} object={lineGeom} attach="geometry" />

--- a/src/lines/LineMaterial.ts
+++ b/src/lines/LineMaterial.ts
@@ -401,6 +401,25 @@ class LineMaterial extends ShaderMaterial {
           }
         },
       },
+      dashed: {
+        enumerable: true,
+
+        get: function () {
+          return Boolean('USE_DASH' in this.defines)
+        },
+
+        set: function (value) {
+          if (Boolean(value) !== Boolean('USE_DASH' in this.defines)) {
+            this.needsUpdate = true
+          }
+
+          if (value) {
+            this.defines.USE_DASH = ''
+          } else {
+            delete this.defines.USE_DASH
+          }
+        },
+      },
     })
 
     this.setValues(parameters)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The `useLayoutEffect` example to define `USE_DASH` isn't a very intuitive API. 

### What

<!-- what have you done, if its a bug, whats your solution? -->

The `USE_DASH` define is automatically set and unset based on the dashed property.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Storybook entry added
- [x] Ready to be merged

There wasn't any documentation before for this as far as I can see, this makes it do the 'expected thing'. I've added a prop to the storybook to see it in action.

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
