### PR TITLE
fix: LineMaterial accepts THREE Colors

### DIFF
--- a/src/lines/LineMaterial.ts
+++ b/src/lines/LineMaterial.ts
@@ -1,4 +1,4 @@
-import { ShaderLib, ShaderMaterial, UniformsLib, UniformsUtils, Vector2, ShaderMaterialParameters } from 'three'
+import { ShaderLib, ShaderMaterial, UniformsLib, UniformsUtils, Vector2, ShaderMaterialParameters, Color } from 'three'
 
 import { ColorOptions } from '../types/shared'
 
@@ -270,7 +270,7 @@ class LineMaterial extends ShaderMaterial {
 
   public dashed = false
 
-  public color: number = 0
+  public color: Color = new Color(0x000000)
   public lineWidth: number = 0
   public dashScale: number = 0
   public dashOffset: number = 0
@@ -300,7 +300,8 @@ class LineMaterial extends ShaderMaterial {
         },
 
         set: function (value) {
-          this.uniforms.diffuse.value = value
+          const colorObj = new Color(value)
+          this.uniforms.diffuse.value = colorObj.getHex()
         },
       },
       linewidth: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Resolves #44

### What

<!-- what have you done, if its a bug, whats your solution? -->

The setter for the color builds a THREE.Color instance, which will consume any of the `ColorOptions` as specified in the types.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
