### PR TITLE
fix: move setting touchAction to .connect in orbit controls

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -96,10 +96,6 @@ class OrbitControls extends EventDispatcher {
 
     this.object = object
     this.domElement = domElement
-    // disables touch scroll
-    // touch-action needs to be defined for pointer events to work on mobile
-    // https://stackoverflow.com/a/48254578
-    this.domElement && (this.domElement.style.touchAction = 'none')
 
     // for reset
     this.target0 = this.target.clone()
@@ -304,6 +300,10 @@ class OrbitControls extends EventDispatcher {
         )
       }
       scope.domElement = domElement
+      // disables touch scroll
+      // touch-action needs to be defined for pointer events to work on mobile
+      // https://stackoverflow.com/a/48254578
+      scope.domElement.style.touchAction = 'none'
       scope.domElement.addEventListener('contextmenu', onContextMenu)
       scope.domElement.addEventListener('pointerdown', onPointerDown)
       scope.domElement.addEventListener('pointercancel', onPointerCancel)


### PR DESCRIPTION
Enables a temporary fix for mobile pointer events in combination with how it's currenly wired in `drei`, see https://github.com/pmndrs/drei/issues/467 and https://github.com/pmndrs/drei/issues/470. Since `.connect` is called in [L968](https://github.com/pmndrs/three-stdlib/blob/main/src/controls/OrbitControls.ts#L968) anyway, it should behave the same as before if the `domElement` param is passed to the ctor. This is a stopgap measure until the [final API is settled](https://github.com/mrdoob/three.js/pull/21224#issuecomment-873099170).