### PR TITLE
Fix LineSegments2 raycaster

### DIFF
--- a/src/lines/LineSegments2.ts
+++ b/src/lines/LineSegments2.ts
@@ -83,7 +83,7 @@ class LineSegments2 extends Mesh<LineSegmentsGeometry, LineMaterial> {
     // pick a point 1 unit out along the ray to avoid the ray origin
     // sitting at the camera origin which will cause "w" to be 0 when
     // applying the projection matrix.
-    ray.at(1, new Vector3(this.ssOrigin.x, this.ssOrigin.y, this.ssOrigin.z))
+    ray.at(1, (this.ssOrigin as unknown) as Vector3)
 
     // ndc space [ - 1.0, 1.0 ]
     this.ssOrigin.w = 1


### PR DESCRIPTION
### Why

The raycast method for Line2 and LineSegments2 is current broken because it discards the value of the ray. It had been changed from the original implementation to satisfy the type checker, presumably.

### What

This fix changes the implementation back to the original by using a type cast instead. You can see this branch follows the original implementation at https://github.com/mrdoob/three.js/blob/e8877dfb85ae017f53ef8d91237909bc162f524b/examples/jsm/lines/LineSegments2.js#L165

### Checklist

- [x] Ready to be merged
