### PR TITLE
fix(card): change `addPointer` call line to before `addEventListener`

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -688,12 +688,12 @@ class OrbitControls extends EventDispatcher {
     function onPointerDown(event: PointerEvent) {
       if (scope.enabled === false) return
 
+      addPointer(event)
+
       if (pointers.length === 0) {
         scope.domElement?.ownerDocument.addEventListener('pointermove', onPointerMove)
         scope.domElement?.ownerDocument.addEventListener('pointerup', onPointerUp)
       }
-
-      addPointer(event)
 
       if (event.pointerType === 'touch') {
         onTouchStart(event)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

When `getSecondPointerPosition` is called, **`pointers[0]` may be 'undefined'**.

> TypeError: undefined is not an object (evaluating 'Z[0].pointerId')
  at getSecondPointerPosition(webpack://_N_E/../../.yarn/__virtual__/three-stdlib-virtual-9e9a05067f/0/cache/three-stdlib-npm-2.4.0-815db58d73-9d995e0146.zip/node_modules/three-stdlib/controls/OrbitControls.js:947:52)
  at handleTouchMoveRotate(webpack://_N_E/../../.yarn/__virtual__/three-stdlib-virtual-9e9a05067f/0/cache/three-stdlib-npm-2.4.0-815db58d73-9d995e0146.zip/node_modules/three-stdlib/controls/OrbitControls.js:611:26)
  at onTouchMove(webpack://_N_E/../../.yarn/__virtual__/three-stdlib-virtual-9e9a05067f/0/cache/three-stdlib-npm-2.4.0-815db58d73-9d995e0146.zip/node_modules/three-stdlib/controls/OrbitControls.js:883:11)
  at onPointerMove(webpack://_N_E/../../.yarn/__virtual__/three-stdlib-virtual-9e9a05067f/0/cache/three-stdlib-npm-2.4.0-815db58d73-9d995e0146.zip/node_modules/three-stdlib/controls/OrbitControls.js:691:9)

When the `pointerdown` event is triggered, `onPointerDown` performs the following process.

1. Register the `pointermove` event listener.
2. Add a pointer.

At this time, if the `pointmove` event listener is called before step 2 is executed, `pointers[0]` becomes `undefined`, and thus a reference error occurs.

### What

Change `addPointer` call line to before `addEventListener` to `pointermove` event.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
