### PR TITLE
#85-fix-mousedown-event-in-transformcontrols

### DIFF
--- a/src/controls/TransformControls.ts
+++ b/src/controls/TransformControls.ts
@@ -297,7 +297,7 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
       }
 
       this.dragging = true
-      this.mouseDownEvent.type = this.mode
+      this.mouseDownEvent.mode = this.mode
       this.dispatchEvent(this.mouseDownEvent)
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Fixes #85 

### What

<!-- what have you done, if its a bug, whats your solution? -->

in TransformControls.ts:300

`this.mouseDownEvent.type = this._mode `
should be
`this.mouseDownEvent.mode = this._mode `
