### PR TITLE
fix: curly bracket position in USDZExporter

### DIFF
--- a/src/exporters/USDZExporter.ts
+++ b/src/exporters/USDZExporter.ts
@@ -383,8 +383,8 @@ ${array.join('')}
     }
 
     return `
-  {
-      def Material "Material_${material.id}"
+    def Material "Material_${material.id}"
+    {
         def Shader "PreviewSurface"
         {
             uniform token info:id = "UsdPreviewSurface"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

This PR resolves #99. There was a problem creating USDZ files.

### What

<!-- what have you done, if its a bug, whats your solution? -->
The problem was, that a curly bracket was in the wrong line.
The opening `{` has to be after the Material definition `def Material "Material" {`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated (documentation didn't need an update)
- [x] Storybook entry added (there is no storybook entry for the USDZExporter)
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
