### PR TITLE
chore: set private-property-in-object to loose: false

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,6 +34,7 @@ const getBabelOptions = ({ useESModules }, targets) => ({
   ],
   plugins: [
     ['@babel/plugin-proposal-private-methods', { loose: false }],
+    ['@babel/plugin-proposal-private-property-in-object', { loose: false }],
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-optional-chaining',
     ['@babel/transform-runtime', { regenerator: false, useESModules }],


### PR DESCRIPTION
### Why

Running build generates a wall of text with hundreds of entries like:

```
Though the "loose" option was set to "true" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "false" for @babel/plugin-proposal-private-methods.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-property-in-object", { "loose": false }]
to the "plugins" section of your Babel config.
```

### What

Set the `loose` property to `false` for the plugin `@babel/plugin-proposal-private-property-in-object`

### Checklist

- [x] Ready to be merged
