### PR TITLE
chore: prompt people to include their @types/three version

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -17,6 +17,7 @@ assignees: ''
 -->
 
 - `three` version:
+- `@types/three` version:
 - `three-stdlib` version:
 
 ### Problem description:


### PR DESCRIPTION
### Why

We get bug reports like #123 where the types between `three` and `@types/three` do not match and cause confusion.

### What

Added a prompt for `@types/three` to the bug report template.

### Checklist

- [x] Ready to be merged
