### PR TITLE
minor: Update peerDependency of three to r137

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "zstddec": "^0.0.2"
   },
   "peerDependencies": {
-    "three": ">=0.128.0"
+    "three": ">=0.137.0"
   }
 }


### PR DESCRIPTION
### Why

#115 added usage of FramebufferTexture that was introduced in three r136, but did not bump the peerDependencies

### What

Bumped the peerDependency of three to v0.137.0

Fixes #129 

### Checklist

- [x] Ready to be merged

