### PR TITLE
Bare specifier "types/shared" is ambiguous

### DIFF
--- a/src/modifiers/CurveModifier.ts
+++ b/src/modifiers/CurveModifier.ts
@@ -19,7 +19,7 @@ import {
   BufferGeometry,
 } from 'three'
 
-import { TUniform } from 'types/shared'
+import { TUniform } from '../types/shared'
 
 /**
  * Make a new DataTexture to store the descriptions of the curves.


### PR DESCRIPTION
Should it resolve to an external package "types/shared" if one is declared in an import-map or a package.json dependency? Probably not.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
