### PR TITLE
fix(Lensflare): FramebufferTexture => Texture

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "zstddec": "^0.0.2"
   },
   "peerDependencies": {
-    "three": ">=0.137.0"
+    "three": ">=0.122.0"
   }
 }

--- a/src/objects/Lensflare.js
+++ b/src/objects/Lensflare.js
@@ -2,17 +2,19 @@ import {
   AdditiveBlending,
   Box2,
   BufferGeometry,
+  ClampToEdgeWrapping,
   Color,
-  FramebufferTexture,
+  DataTexture,
   InterleavedBuffer,
   InterleavedBufferAttribute,
   Mesh,
   MeshBasicMaterial,
+  NearestFilter,
+  RGBAFormat,
   RawShaderMaterial,
   Vector2,
   Vector3,
   Vector4,
-  RGBAFormat,
 } from 'three'
 
 class Lensflare extends Mesh {
@@ -29,9 +31,17 @@ class Lensflare extends Mesh {
     const positionView = new Vector3()
 
     // textures
+    const tempMap = new DataTexture(new Uint8Array(16 * 16 * 3), 16, 16, RGBAFormat)
+    tempMap.minFilter = NearestFilter
+    tempMap.magFilter = NearestFilter
+    tempMap.wrapS = ClampToEdgeWrapping
+    tempMap.wrapT = ClampToEdgeWrapping
 
-    const tempMap = new FramebufferTexture(16, 16, RGBAFormat)
-    const occlusionMap = new FramebufferTexture(16, 16, RGBAFormat)
+    const occlusionMap = new DataTexture(new Uint8Array(16 * 16 * 3), 16, 16, RGBAFormat)
+    occlusionMap.minFilter = NearestFilter
+    occlusionMap.magFilter = NearestFilter
+    occlusionMap.wrapS = ClampToEdgeWrapping
+    occlusionMap.wrapT = ClampToEdgeWrapping
 
     // material
 


### PR DESCRIPTION
Fixes #143.

Reverts the refactor of Lensflare made in #115 to loosen the three peer dep.


### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
