### PR TITLE
chore: add `getRaycaster` for `DragControls`

### DIFF
--- a/src/controls/DragControls.ts
+++ b/src/controls/DragControls.ts
@@ -57,7 +57,7 @@ class DragControls extends EventDispatcher {
 
   public getObjects = (): Object3D[] => this._objects
 
-  public getRaycaster = (): Raycaster => this._raycaster;
+  public getRaycaster = (): Raycaster => this._raycaster
 
   private onMouseMove = (event: MouseEvent): void => {
     const rect = this._domElement.getBoundingClientRect()

--- a/src/controls/DragControls.ts
+++ b/src/controls/DragControls.ts
@@ -57,6 +57,8 @@ class DragControls extends EventDispatcher {
 
   public getObjects = (): Object3D[] => this._objects
 
+  public getRaycaster = (): Raycaster => this._raycaster;
+
   private onMouseMove = (event: MouseEvent): void => {
     const rect = this._domElement.getBoundingClientRect()
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
`DragControls` in `three` has `getRaycaster` function
https://threejs.org/docs/index.html#examples/en/controls/DragControls
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
