### PR TITLE
Adding the reset method to TransformControls

### DIFF
--- a/.storybook/stories/TransformControls.stories.ts
+++ b/.storybook/stories/TransformControls.stories.ts
@@ -9,10 +9,15 @@ export default {
   title: 'Controls/Transform',
 }
 
+function onEscKey(e: KeyboardEvent, controls: TransformControls) {
+  controls.reset()
+}
+
 export const Default = () => {
   // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
   useEffect(() => {
     const { renderer, scene, camera, render } = useThree({
+      // @ts-ignore
       orbit: false,
       //   useFrame: (_, delta) => {},
     })
@@ -31,7 +36,11 @@ export const Default = () => {
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
+    const cb = (e: KeyboardEvent) => e.key === 'Escape' && control.reset()
+    document.addEventListener('keydown', cb)
+
     return () => {
+      document.removeEventListener('keydown', cb)
       renderer.dispose()
     }
   }, [])
@@ -62,7 +71,11 @@ export const RotateStory = () => {
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
+    const cb = (e: KeyboardEvent) => e.key === 'Escape' && control.reset()
+    document.addEventListener('keydown', cb)
+
     return () => {
+      document.removeEventListener('keydown', cb)
       renderer.dispose()
     }
   }, [])
@@ -75,6 +88,7 @@ export const ScaleStory = () => {
   // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
   useEffect(() => {
     const { renderer, scene, camera, render } = useThree({
+      // @ts-ignore
       orbit: false,
       //   useFrame: (_, delta) => {},
     })
@@ -95,7 +109,11 @@ export const ScaleStory = () => {
     camera.lookAt(mesh.position)
     scene.background = new Color(0x000000).convertSRGBToLinear()
 
+    const cb = (e: KeyboardEvent) => e.key === 'Escape' && control.reset()
+    document.addEventListener('keydown', cb)
+
     return () => {
+      document.removeEventListener('keydown', cb)
       renderer.dispose()
     }
   }, [])

--- a/src/controls/TransformControls.ts
+++ b/src/controls/TransformControls.ts
@@ -209,6 +209,24 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
 
     return this
   }
+  
+  // Reset 
+  public reset = (): this => {
+
+    if (!this.enabled) return this
+
+    if (this.dragging) {
+      if (this.object !== undefined) {
+        this.object.position.copy(this.positionStart)
+        this.object.quaternion.copy(this.quaternionStart)
+        this.object.scale.copy(this.scaleStart)
+        this.dispatchEvent(this.changeEvent)
+        this.dispatchEvent(this.objectChangeEvent)
+        this.pointStart.copy(this.pointEnd)}
+    }
+
+    return this
+  }
 
   public updateMatrixWorld = (): void => {
     if (this.object !== undefined) {

--- a/src/controls/TransformControls.ts
+++ b/src/controls/TransformControls.ts
@@ -209,10 +209,9 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
 
     return this
   }
-  
-  // Reset 
-  public reset = (): this => {
 
+  // Reset
+  public reset = (): this => {
     if (!this.enabled) return this
 
     if (this.dragging) {
@@ -222,7 +221,8 @@ class TransformControls<TCamera extends Camera = Camera> extends Object3D {
         this.object.scale.copy(this.scaleStart)
         this.dispatchEvent(this.changeEvent)
         this.dispatchEvent(this.objectChangeEvent)
-        this.pointStart.copy(this.pointEnd)}
+        this.pointStart.copy(this.pointEnd)
+      }
     }
 
     return this


### PR DESCRIPTION
### Why

The .reset() method of TransformControls was present in [three.js] but not in three-stdlib : 

 .reset () : undefined
Resets the object's position, rotation and scale to when the current transform began. 

### What

I wrapped it 

### Checklist
<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged
