### PR TITLE
fix: use arrow function in scene.traverse argument

### DIFF
--- a/src/exporters/STLExporter.ts
+++ b/src/exporters/STLExporter.ts
@@ -52,7 +52,7 @@ class STLExporter {
 
     //
 
-    scene.traverse(function (object) {
+    scene.traverse((object) => {
       if (object instanceof Mesh && object.isMesh) {
         const geometry = object.geometry
 


### PR DESCRIPTION
### Why

resolves #160 

### What

The `scene.traverse` method receives an anonymous function as an argument that leads to `this` being undefined inside the function body. By using an arrow function we make sure that `this` references the upper scope class instance.