### PR TITLE
feat(XRHandMeshModel): add custom model path arg

### DIFF
--- a/src/webxr/XRHandMeshModel.js
+++ b/src/webxr/XRHandMeshModel.js
@@ -4,15 +4,15 @@ const DEFAULT_HAND_PROFILE_PATH =
   'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles/generic-hand/'
 
 class XRHandMeshModel {
-  constructor(handModel, controller, path, handedness) {
+  constructor(handModel, controller, path, handedness, customModel) {
     this.controller = controller
     this.handModel = handModel
 
     this.bones = []
 
     const loader = new GLTFLoader()
-    loader.setPath(path || DEFAULT_HAND_PROFILE_PATH)
-    loader.load(`${handedness}.glb`, (gltf) => {
+    if (!customModel) loader.setPath(path || DEFAULT_HAND_PROFILE_PATH)
+    loader.load(customModel ?? `${handedness}.glb`, (gltf) => {
       const object = gltf.scene.children[0]
       this.handModel.add(object)
 


### PR DESCRIPTION
### Why

XRHandMeshModel assumes a static folder layout of `/path/to/folder/[handedness].glb` whereas some users may prefer to load an absolute path from CDN.

### What

This PR mirrors https://github.com/pmndrs/react-xr/pull/62, adding an absolute path arg to specify a custom model path. Also properly handles dispose for OculusHandModel.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
