### PR TITLE
feat(webxr): convert buttons to TS, passthrough vr sessioninit

### DIFF
--- a/src/webxr/ARButton.ts
+++ b/src/webxr/ARButton.ts
@@ -1,18 +1,11 @@
 import { Navigator, WebGLRenderer, XRSession, XRSessionInit } from 'three'
 
-export interface ARButtonSessionInit extends XRSessionInit {
-  domOverlay?: { root: HTMLElement }
-}
-
 class ARButton {
-  static createButton(
-    renderer: WebGLRenderer,
-    sessionInit: ARButtonSessionInit = {},
-  ): HTMLButtonElement | HTMLAnchorElement {
+  static createButton(renderer: WebGLRenderer, sessionInit: XRSessionInit = {}): HTMLButtonElement | HTMLAnchorElement {
     const button = document.createElement('button')
 
     function showStartAR(/*device*/): void {
-      if (sessionInit.domOverlay === undefined) {
+      if ((sessionInit as any).domOverlay === undefined) {
         const overlay = document.createElement('div')
         overlay.style.display = 'none'
         document.body.appendChild(overlay)
@@ -39,7 +32,7 @@ class ARButton {
         }
 
         sessionInit.optionalFeatures.push('dom-overlay')
-        sessionInit.domOverlay = { root: overlay }
+        ;(sessionInit as any).domOverlay = { root: overlay }
       }
 
       //
@@ -54,7 +47,7 @@ class ARButton {
         await renderer.xr.setSession(session)
 
         button.textContent = 'STOP AR'
-        sessionInit.domOverlay!.root.style.display = ''
+        ;(sessionInit as any).domOverlay!.root.style.display = ''
 
         currentSession = session
       }
@@ -63,7 +56,7 @@ class ARButton {
         currentSession!.removeEventListener('end', onSessionEnded)
 
         button.textContent = 'START AR'
-        sessionInit.domOverlay!.root.style.display = 'none'
+        ;(sessionInit as any).domOverlay!.root.style.display = 'none'
 
         currentSession = null
       }

--- a/src/webxr/ARButton.ts
+++ b/src/webxr/ARButton.ts
@@ -11,7 +11,7 @@ class ARButton {
   ): HTMLButtonElement | HTMLAnchorElement {
     const button = document.createElement('button')
 
-    function showStartAR(/*device*/) {
+    function showStartAR(/*device*/): void {
       if (sessionInit.domOverlay === undefined) {
         const overlay = document.createElement('div')
         overlay.style.display = 'none'
@@ -46,7 +46,7 @@ class ARButton {
 
       let currentSession: XRSession | null = null
 
-      async function onSessionStarted(session: XRSession) {
+      async function onSessionStarted(session: XRSession): Promise<void> {
         session.addEventListener('end', onSessionEnded)
 
         renderer.xr.setReferenceSpaceType('local')
@@ -59,7 +59,7 @@ class ARButton {
         currentSession = session
       }
 
-      function onSessionEnded(/*event*/) {
+      function onSessionEnded(/*event*/): void {
         currentSession!.removeEventListener('end', onSessionEnded)
 
         button.textContent = 'START AR'
@@ -78,15 +78,15 @@ class ARButton {
 
       button.textContent = 'START AR'
 
-      button.onmouseenter = function () {
+      button.onmouseenter = (): void => {
         button.style.opacity = '1.0'
       }
 
-      button.onmouseleave = function () {
+      button.onmouseleave = (): void => {
         button.style.opacity = '0.5'
       }
 
-      button.onclick = function () {
+      button.onclick = (): void => {
         if (currentSession === null) {
           ;(navigator as Navigator).xr!.requestSession('immersive-ar', sessionInit).then(onSessionStarted)
         } else {
@@ -95,7 +95,7 @@ class ARButton {
       }
     }
 
-    function disableButton() {
+    function disableButton(): void {
       button.style.display = ''
 
       button.style.cursor = 'auto'
@@ -108,13 +108,13 @@ class ARButton {
       button.onclick = null
     }
 
-    function showARNotSupported() {
+    function showARNotSupported(): void {
       disableButton()
 
       button.textContent = 'AR NOT SUPPORTED'
     }
 
-    function stylizeElement(element: HTMLElement) {
+    function stylizeElement(element: HTMLElement): void {
       element.style.position = 'absolute'
       element.style.bottom = '20px'
       element.style.padding = '12px 6px'

--- a/src/webxr/ARButton.ts
+++ b/src/webxr/ARButton.ts
@@ -1,28 +1,37 @@
+import { Navigator, WebGLRenderer, XRSession, XRSessionInit } from 'three'
+
+export interface ARButtonSessionInit extends XRSessionInit {
+  domOverlay?: { root: HTMLElement }
+}
+
 class ARButton {
-  static createButton(renderer, sessionInit = {}) {
+  static createButton(
+    renderer: WebGLRenderer,
+    sessionInit: ARButtonSessionInit = {},
+  ): HTMLButtonElement | HTMLAnchorElement {
     const button = document.createElement('button')
 
     function showStartAR(/*device*/) {
       if (sessionInit.domOverlay === undefined) {
-        var overlay = document.createElement('div')
+        const overlay = document.createElement('div')
         overlay.style.display = 'none'
         document.body.appendChild(overlay)
 
-        var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-        svg.setAttribute('width', 38)
-        svg.setAttribute('height', 38)
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+        svg.setAttribute('width', '38px')
+        svg.setAttribute('height', '38px')
         svg.style.position = 'absolute'
         svg.style.right = '20px'
         svg.style.top = '20px'
         svg.addEventListener('click', function () {
-          currentSession.end()
+          currentSession?.end()
         })
         overlay.appendChild(svg)
 
-        var path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
         path.setAttribute('d', 'M 12,12 L 28,28 M 28,12 12,28')
         path.setAttribute('stroke', '#fff')
-        path.setAttribute('stroke-width', 2)
+        path.setAttribute('stroke-width', '2px')
         svg.appendChild(path)
 
         if (sessionInit.optionalFeatures === undefined) {
@@ -35,9 +44,9 @@ class ARButton {
 
       //
 
-      let currentSession = null
+      let currentSession: XRSession | null = null
 
-      async function onSessionStarted(session) {
+      async function onSessionStarted(session: XRSession) {
         session.addEventListener('end', onSessionEnded)
 
         renderer.xr.setReferenceSpaceType('local')
@@ -45,16 +54,16 @@ class ARButton {
         await renderer.xr.setSession(session)
 
         button.textContent = 'STOP AR'
-        sessionInit.domOverlay.root.style.display = ''
+        sessionInit.domOverlay!.root.style.display = ''
 
         currentSession = session
       }
 
       function onSessionEnded(/*event*/) {
-        currentSession.removeEventListener('end', onSessionEnded)
+        currentSession!.removeEventListener('end', onSessionEnded)
 
         button.textContent = 'START AR'
-        sessionInit.domOverlay.root.style.display = 'none'
+        sessionInit.domOverlay!.root.style.display = 'none'
 
         currentSession = null
       }
@@ -79,7 +88,7 @@ class ARButton {
 
       button.onclick = function () {
         if (currentSession === null) {
-          navigator.xr.requestSession('immersive-ar', sessionInit).then(onSessionStarted)
+          ;(navigator as Navigator).xr!.requestSession('immersive-ar', sessionInit).then(onSessionStarted)
         } else {
           currentSession.end()
         }
@@ -105,7 +114,7 @@ class ARButton {
       button.textContent = 'AR NOT SUPPORTED'
     }
 
-    function stylizeElement(element) {
+    function stylizeElement(element: HTMLElement) {
       element.style.position = 'absolute'
       element.style.bottom = '20px'
       element.style.padding = '12px 6px'
@@ -126,8 +135,9 @@ class ARButton {
 
       stylizeElement(button)
 
-      navigator.xr
-        .isSessionSupported('immersive-ar')
+      // Query for session mode
+      ;(navigator as Navigator)
+        .xr!.isSessionSupported('immersive-ar')
         .then(function (supported) {
           supported ? showStartAR() : showARNotSupported()
         })

--- a/src/webxr/VRButton.ts
+++ b/src/webxr/VRButton.ts
@@ -1,13 +1,13 @@
 import { Navigator, WebGLRenderer, XRSession, XRSessionInit } from 'three'
 
 class VRButton {
-  static createButton(renderer: WebGLRenderer, sessionInit: XRSessionInit = {}) {
+  static createButton(renderer: WebGLRenderer, sessionInit: XRSessionInit = {}): HTMLButtonElement | HTMLAnchorElement {
     const button = document.createElement('button')
 
-    function showEnterVR(/*device*/) {
+    function showEnterVR(/*device*/): void {
       let currentSession: XRSession | null = null
 
-      async function onSessionStarted(session: XRSession) {
+      async function onSessionStarted(session: XRSession): Promise<void> {
         session.addEventListener('end', onSessionEnded)
 
         await renderer.xr.setSession(session)
@@ -16,7 +16,7 @@ class VRButton {
         currentSession = session
       }
 
-      function onSessionEnded(/*event*/) {
+      function onSessionEnded(/*event*/): void {
         currentSession!.removeEventListener('end', onSessionEnded)
 
         button.textContent = 'ENTER VR'
@@ -34,15 +34,15 @@ class VRButton {
 
       button.textContent = 'ENTER VR'
 
-      button.onmouseenter = function () {
+      button.onmouseenter = (): void => {
         button.style.opacity = '1.0'
       }
 
-      button.onmouseleave = function () {
+      button.onmouseleave = (): void => {
         button.style.opacity = '0.5'
       }
 
-      button.onclick = function () {
+      button.onclick = (): void => {
         if (currentSession === null) {
           // WebXR's requestReferenceSpace only works if the corresponding feature
           // was requested at session creation time. For simplicity, just ask for
@@ -64,7 +64,7 @@ class VRButton {
       }
     }
 
-    function disableButton() {
+    function disableButton(): void {
       button.style.display = ''
 
       button.style.cursor = 'auto'
@@ -77,13 +77,13 @@ class VRButton {
       button.onclick = null
     }
 
-    function showWebXRNotFound() {
+    function showWebXRNotFound(): void {
       disableButton()
 
       button.textContent = 'VR NOT SUPPORTED'
     }
 
-    function stylizeElement(element: HTMLElement) {
+    function stylizeElement(element: HTMLElement): void {
       element.style.position = 'absolute'
       element.style.bottom = '20px'
       element.style.padding = '12px 6px'


### PR DESCRIPTION
### Why

The current ARButton and VRButton are not aligned with one another in allowing user-specified session init properties.

### What

This PR allows session init to be specified in immersive-vr and converts both buttons to TS.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
