### PR TITLE
fix(OculusHandModel): don't accept array

### DIFF
--- a/src/webxr/OculusHandModel.ts
+++ b/src/webxr/OculusHandModel.ts
@@ -18,7 +18,7 @@ class OculusHandModel extends Object3D {
   mesh: Mesh | null
   xrInputSource: XRInputSource | null
 
-  constructor(controller: Object3D, customModels?: string[]) {
+  constructor(controller: Object3D, leftModelPath?: string, rightModelPath?: string) {
     super()
 
     this.controller = controller
@@ -39,7 +39,7 @@ class OculusHandModel extends Object3D {
           controller,
           undefined,
           xrInputSource.handedness,
-          xrInputSource.handedness === 'left' ? customModels?.[0] : customModels?.[1],
+          xrInputSource.handedness === 'left' ? leftModelPath : rightModelPath,
         )
       }
     })

--- a/src/webxr/XRHandMeshModel.ts
+++ b/src/webxr/XRHandMeshModel.ts
@@ -15,7 +15,7 @@ class XRHandMeshModel {
     controller: Object3D,
     path: string = DEFAULT_HAND_PROFILE_PATH,
     handedness: string,
-    customModel?: string,
+    customModelPath?: string,
   ) {
     this.controller = controller
     this.handModel = handModel
@@ -23,8 +23,8 @@ class XRHandMeshModel {
     this.bones = []
 
     const loader = new GLTFLoader()
-    if (!customModel) loader.setPath(path)
-    loader.load(customModel ?? `${handedness}.glb`, (gltf: { scene: Object3D }) => {
+    if (!customModelPath) loader.setPath(path)
+    loader.load(customModelPath ?? `${handedness}.glb`, (gltf: { scene: Object3D }) => {
       const object = gltf.scene.children[0]
       this.handModel.add(object)
 


### PR DESCRIPTION
Accepts separate args for left/right hands rather than an array, which can falsly break reference.