### PR TITLE
fix: deprecate usage of *BufferGeometry aliases

### DIFF
--- a/.storybook/stories/BasicScene.stories.ts
+++ b/.storybook/stories/BasicScene.stories.ts
@@ -4,7 +4,7 @@ import {
   PointLight,
   SpotLight,
   Mesh,
-  IcosahedronBufferGeometry,
+  IcosahedronGeometry,
   MeshStandardMaterial,
   Color,
 } from 'three'
@@ -19,7 +19,7 @@ export default {
 export const Default = () => {
   // must run in this so the canvas has mounted in the iframe & can be accessed by `three`
   useEffect(() => {
-    const mesh = new Mesh(new IcosahedronBufferGeometry(1), new MeshStandardMaterial({ color: 'pink' }))
+    const mesh = new Mesh(new IcosahedronGeometry(1), new MeshStandardMaterial({ color: 'pink' }))
 
     const ambientLight = new AmbientLight('white', 0.2)
     const directionalLight = new DirectionalLight('pink', 2)

--- a/demos/ssr/components/Scene.tsx
+++ b/demos/ssr/components/Scene.tsx
@@ -22,7 +22,7 @@ export const Scene = (): JSX.Element => {
       <Controls />
       <Lights />
       <mesh ref={meshRef}>
-        <icosahedronBufferGeometry args={[1]} />
+        <icosahedronGeometry args={[1]} />
         <meshStandardMaterial color="pink" roughness={0} />
       </mesh>
     </>

--- a/src/geometries/ConvexGeometry.js
+++ b/src/geometries/ConvexGeometry.js
@@ -13,7 +13,7 @@ class ConvexGeometry extends BufferGeometry {
     const normals = []
 
     if (ConvexHull === undefined) {
-      console.error('THREE.ConvexBufferGeometry: ConvexBufferGeometry relies on ConvexHull')
+      console.error('THREE.ConvexGeometry: ConvexGeometry relies on ConvexHull')
     }
 
     const convexHull = new ConvexHull().setFromPoints(points)

--- a/src/misc/ProgressiveLightmap.js
+++ b/src/misc/ProgressiveLightmap.js
@@ -6,7 +6,6 @@ import {
   MeshPhongMaterial,
   DoubleSide,
   PlaneGeometry,
-  PlaneGeometry,
   Mesh,
 } from 'three'
 import potpack from 'potpack'

--- a/src/misc/ProgressiveLightmap.js
+++ b/src/misc/ProgressiveLightmap.js
@@ -6,7 +6,7 @@ import {
   MeshPhongMaterial,
   DoubleSide,
   PlaneGeometry,
-  PlaneBufferGeometry,
+  PlaneGeometry,
   Mesh,
 } from 'three'
 import potpack from 'potpack'
@@ -277,7 +277,7 @@ class ProgressiveLightMap {
       this.compiled = true
     }
 
-    this.blurringPlane = new Mesh(new PlaneBufferGeometry(1, 1), blurMaterial)
+    this.blurringPlane = new Mesh(new PlaneGeometry(1, 1), blurMaterial)
     this.blurringPlane.name = 'Blurring Plane'
     this.blurringPlane.frustumCulled = false
     this.blurringPlane.renderOrder = 0


### PR DESCRIPTION
Deprecates usage of `*BufferGeometry` aliases since https://github.com/mrdoob/three.js/pull/24352.