### PR TITLE
fix(types): move @types/offscreencanvas to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@storybook/manager-webpack5": "^6.4.14",
     "@storybook/preset-typescript": "^3.0.0",
     "@types/draco3d": "^1.4.0",
-    "@types/offscreencanvas": "^2019.6.4",
     "@types/three": "^0.137.0",
     "@typescript-eslint/eslint-plugin": "^4.28.0",
     "@typescript-eslint/parser": "^4.28.0",
@@ -97,6 +96,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.7",
+    "@types/offscreencanvas": "^2019.6.4",
     "@webgpu/glslang": "^0.0.15",
     "chevrotain": "^10.1.2",
     "draco3d": "^1.4.1",


### PR DESCRIPTION
### Why

The declaration files reference OffscreenCanvas, therefore it should be a dependency instead of a devDependency:

```
node_modules/three-stdlib/exporters/GLTFExporter.d.ts:41:75 - error TS2304: Cannot find name 'OffscreenCanvas'.

41 declare type ImageRepresentation = HTMLImageElement | HTMLCanvasElement | OffscreenCanvas | ImageBitmap;
                                                                             ~~~~~~~~~~~~~~~
```

### What

Moved `@types/offscreen-canvas` to dependencies.

### Checklist

- [x] Ready to be merged
