### PR TITLE
Add ParametricGeometry and fix the import in ParametricGeometries

### DIFF
--- a/src/geometries/ParametricGeometries.js
+++ b/src/geometries/ParametricGeometries.js
@@ -1,4 +1,5 @@
-import { BufferGeometry, Curve, ParametricGeometry, Vector3 } from 'three'
+import { BufferGeometry, Curve, Vector3 } from 'three'
+import { ParametricGeometry } from './ParametricGeometry'
 
 /**
  * Experimenting of primitive geometry creation using Surface Parametric equations

--- a/src/geometries/ParametricGeometry.js
+++ b/src/geometries/ParametricGeometry.js
@@ -1,0 +1,107 @@
+/**
+ * Parametric Surfaces Geometry
+ * based on the brilliant article by @prideout https://prideout.net/blog/old/blog/index.html@p=44.html
+ */
+
+import { BufferGeometry, Float32BufferAttribute, Vector3 } from 'three'
+
+class ParametricGeometry extends BufferGeometry {
+  constructor(func = (u, v, target) => target.set(u, v, Math.cos(u) * Math.sin(v)), slices = 8, stacks = 8) {
+    super()
+
+    this.type = 'ParametricGeometry'
+
+    this.parameters = {
+      func: func,
+      slices: slices,
+      stacks: stacks,
+    }
+
+    // buffers
+
+    const indices = []
+    const vertices = []
+    const normals = []
+    const uvs = []
+
+    const EPS = 0.00001
+
+    const normal = new Vector3()
+
+    const p0 = new Vector3(),
+      p1 = new Vector3()
+    const pu = new Vector3(),
+      pv = new Vector3()
+
+    // generate vertices, normals and uvs
+
+    const sliceCount = slices + 1
+
+    for (let i = 0; i <= stacks; i++) {
+      const v = i / stacks
+
+      for (let j = 0; j <= slices; j++) {
+        const u = j / slices
+
+        // vertex
+
+        func(u, v, p0)
+        vertices.push(p0.x, p0.y, p0.z)
+
+        // normal
+
+        // approximate tangent vectors via finite differences
+
+        if (u - EPS >= 0) {
+          func(u - EPS, v, p1)
+          pu.subVectors(p0, p1)
+        } else {
+          func(u + EPS, v, p1)
+          pu.subVectors(p1, p0)
+        }
+
+        if (v - EPS >= 0) {
+          func(u, v - EPS, p1)
+          pv.subVectors(p0, p1)
+        } else {
+          func(u, v + EPS, p1)
+          pv.subVectors(p1, p0)
+        }
+
+        // cross product of tangent vectors returns surface normal
+
+        normal.crossVectors(pu, pv).normalize()
+        normals.push(normal.x, normal.y, normal.z)
+
+        // uv
+
+        uvs.push(u, v)
+      }
+    }
+
+    // generate indices
+
+    for (let i = 0; i < stacks; i++) {
+      for (let j = 0; j < slices; j++) {
+        const a = i * sliceCount + j
+        const b = i * sliceCount + j + 1
+        const c = (i + 1) * sliceCount + j + 1
+        const d = (i + 1) * sliceCount + j
+
+        // faces one and two
+
+        indices.push(a, b, d)
+        indices.push(b, c, d)
+      }
+    }
+
+    // build geometry
+
+    this.setIndex(indices)
+    this.setAttribute('position', new Float32BufferAttribute(vertices, 3))
+    this.setAttribute('normal', new Float32BufferAttribute(normals, 3))
+    this.setAttribute('uv', new Float32BufferAttribute(uvs, 2))
+  }
+}
+
+export { ParametricGeometry }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

With three@144 the import for `ParametricGeometry` seems to break. This causes components like Drei's `OrbitControls` to break and other issues. See issue https://github.com/pmndrs/three-stdlib/issues/178 and https://github.com/pmndrs/drei/issues/1029.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Fix the import and add `ParametricGeometry`.
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
