### PR TITLE
fix(water2): fix water2 shader enum wrong.

### DIFF
--- a/src/objects/Water2.js
+++ b/src/objects/Water2.js
@@ -38,7 +38,7 @@ class Water2 extends Mesh {
     const flowSpeed = options.flowSpeed || 0.03
     const reflectivity = options.reflectivity || 0.02
     const scale = options.scale || 1
-    const shader = options.shader || Water.WaterShader
+    const shader = options.shader || Water2.WaterShader
     const encoding = options.encoding !== undefined ? options.encoding : LinearEncoding
 
     const textureLoader = new TextureLoader()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

fix "Uncaught ReferenceError: Water is not defined"
![image](https://user-images.githubusercontent.com/30215105/191897313-c279a96c-9258-44ef-a89c-e74b398ff27b.png)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
