### PR TITLE
fix(GLTFLoader): play nice with headless environments

### DIFF
--- a/src/loaders/GLTFLoader.js
+++ b/src/loaders/GLTFLoader.js
@@ -1927,9 +1927,11 @@ class GLTFParser {
     // Use an ImageBitmapLoader if imageBitmaps are supported. Moves much of the
     // expensive work of uploading a texture to the GPU off the main thread.
 
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent) === true
-    const isFirefox = navigator.userAgent.indexOf('Firefox') > -1
-    const firefoxVersion = isFirefox ? navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1] : -1
+    const isSafari =
+      typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent) === true
+    const isFirefox = typeof navigator !== 'undefined' && navigator.userAgent.indexOf('Firefox') > -1
+    const firefoxVersion =
+      typeof navigator !== 'undefined' && isFirefox ? navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1] : -1
 
     if (typeof createImageBitmap === 'undefined' || isSafari || (isFirefox && firefoxVersion < 98)) {
       this.textureLoader = new TextureLoader(this.options.manager)


### PR DESCRIPTION
#190 introduces a regression where global `navigator` was not null-checked when profiling browser behavior.