### PR TITLE
fix(GLTFLoader): align attenuation

### DIFF
--- a/src/loaders/GLTFLoader.js
+++ b/src/loaders/GLTFLoader.js
@@ -810,7 +810,7 @@ class GLTFMaterialsVolumeExtension {
       pending.push(parser.assignTexture(materialParams, 'thicknessMap', extension.thicknessTexture))
     }
 
-    materialParams.attenuationDistance = extension.attenuationDistance || 0
+    materialParams.attenuationDistance = extension.attenuationDistance || Infinity
 
     const colorArray = extension.attenuationColor || [1, 1, 1]
     materialParams.attenuationColor = new Color(colorArray[0], colorArray[1], colorArray[2])


### PR DESCRIPTION
Mirrors https://github.com/mrdoob/three.js/pull/24622, fixes https://github.com/mrdoob/three.js/issues/24799.