### PR TITLE
Replace old Euler.toVector3 with setFromEuler

### DIFF
--- a/src/animation/CCDIKSolver.js
+++ b/src/animation/CCDIKSolver.js
@@ -305,11 +305,11 @@ class CCDIKSolver {
           }
 
           if (rotationMin !== undefined) {
-            link.rotation.setFromVector3(link.rotation.toVector3(this.vector).max(rotationMin))
+            link.rotation.setFromVector3(this.vector.setFromEuler(link.rotation).max(rotationMin))
           }
 
           if (rotationMax !== undefined) {
-            link.rotation.setFromVector3(link.rotation.toVector3(this.vector).min(rotationMax))
+            link.rotation.setFromVector3(this.vector.setFromEuler(link.rotation).min(rotationMax))
           }
 
           link.updateMatrixWorld(true)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

Fixes https://github.com/pmndrs/three-stdlib/issues/197

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Replace the old `Euler.toVector3()` with `Vector3.setFromEuler()`
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
