### PR TITLE
fix(CCDIKHelper): missing var

### DIFF
--- a/src/animation/CCDIKSolver.js
+++ b/src/animation/CCDIKSolver.js
@@ -64,6 +64,7 @@ class CCDIKHelper extends Object3D {
       return geometry
     }
 
+    const scope = this
     function createTargetMesh() {
       return new Mesh(scope.sphereGeometry, scope.targetSphereMaterial)
     }


### PR DESCRIPTION
`scope` variable was missing

cf. https://github.com/mrdoob/three.js/blob/4f23d857b15b40fd5afd8a6bccaf761812efd70e/examples/js/animation/CCDIKSolver.js#L359
