### PR TITLE
fix: Removing backslash string line continuations

### DIFF
--- a/src/postprocessing/UnrealBloomPass.js
+++ b/src/postprocessing/UnrealBloomPass.js
@@ -284,39 +284,36 @@ UnrealBloomPass.prototype = Object.assign(Object.create(Pass.prototype), {
         direction: { value: new Vector2(0.5, 0.5) },
       },
 
-      vertexShader:
-        'varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}',
-
-      fragmentShader:
-        '#include <common>\
-				varying vec2 vUv;\n\
-				uniform sampler2D colorTexture;\n\
-				uniform vec2 texSize;\
-				uniform vec2 direction;\
-				\
-				float gaussianPdf(in float x, in float sigma) {\
-					return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;\
-				}\
-				void main() {\n\
-					vec2 invSize = 1.0 / texSize;\
-					float fSigma = float(SIGMA);\
-					float weightSum = gaussianPdf(0.0, fSigma);\
-					vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;\
-					for( int i = 1; i < KERNEL_RADIUS; i ++ ) {\
-						float x = float(i);\
-						float w = gaussianPdf(x, fSigma);\
-						vec2 uvOffset = direction * invSize * x;\
-						vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;\
-						vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;\
-						diffuseSum += (sample1 + sample2) * w;\
-						weightSum += 2.0 * w;\
-					}\
-					gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n\
-				}',
+      vertexShader: 'varying vec2 vUv;\n' +
+          'void main() {\n' +
+          '	vUv = uv;\n' +
+          '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
+          '}',
+      fragmentShader: '#include <common>' +
+          'varying vec2 vUv;\n' +
+          'uniform sampler2D colorTexture;\n' +
+          'uniform vec2 texSize;' +
+          'uniform vec2 direction;' +
+          '\n' +
+          'float gaussianPdf(in float x, in float sigma) {' +
+          '	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;' +
+          '}' +
+          'void main() {\n' +
+          '	vec2 invSize = 1.0 / texSize;' +
+          '	float fSigma = float(SIGMA);' +
+          '	float weightSum = gaussianPdf(0.0, fSigma);' +
+          '	vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;' +
+          '	for( int i = 1; i < KERNEL_RADIUS; i ++ ) {' +
+          '		float x = float(i);' +
+          '		float w = gaussianPdf(x, fSigma);' +
+          '		vec2 uvOffset = direction * invSize * x;' +
+          '		vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;' +
+          '		vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;' +
+          '		diffuseSum += (sample1 + sample2) * w;' +
+          '		weightSum += 2.0 * w;' +
+          '	}' +
+          '	gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n' +
+          '}'
     })
   },
 
@@ -339,38 +336,35 @@ UnrealBloomPass.prototype = Object.assign(Object.create(Pass.prototype), {
         bloomRadius: { value: 0.0 },
       },
 
-      vertexShader:
-        'varying vec2 vUv;\n\
-				void main() {\n\
-					vUv = uv;\n\
-					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n\
-				}',
-
-      fragmentShader:
-        'varying vec2 vUv;\
-				uniform sampler2D blurTexture1;\
-				uniform sampler2D blurTexture2;\
-				uniform sampler2D blurTexture3;\
-				uniform sampler2D blurTexture4;\
-				uniform sampler2D blurTexture5;\
-				uniform sampler2D dirtTexture;\
-				uniform float bloomStrength;\
-				uniform float bloomRadius;\
-				uniform float bloomFactors[NUM_MIPS];\
-				uniform vec3 bloomTintColors[NUM_MIPS];\
-				\
-				float lerpBloomFactor(const in float factor) { \
-					float mirrorFactor = 1.2 - factor;\
-					return mix(factor, mirrorFactor, bloomRadius);\
-				}\
-				\
-				void main() {\
-					gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + \
-													 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + \
-													 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + \
-													 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + \
-													 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );\
-				}',
+      vertexShader: 'varying vec2 vUv;\n' +
+          'void main() {\n' +
+          '	vUv = uv;\n' +
+          '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
+          '}',
+      fragmentShader: 'varying vec2 vUv;' +
+          'uniform sampler2D blurTexture1;' +
+          'uniform sampler2D blurTexture2;' +
+          'uniform sampler2D blurTexture3;' +
+          'uniform sampler2D blurTexture4;' +
+          'uniform sampler2D blurTexture5;' +
+          'uniform sampler2D dirtTexture;' +
+          'uniform float bloomStrength;' +
+          'uniform float bloomRadius;' +
+          'uniform float bloomFactors[NUM_MIPS];' +
+          'uniform vec3 bloomTintColors[NUM_MIPS];' +
+          '' +
+          'float lerpBloomFactor(const in float factor) { ' +
+          '	float mirrorFactor = 1.2 - factor;' +
+          '	return mix(factor, mirrorFactor, bloomRadius);' +
+          '}' +
+          '' +
+          'void main() {' +
+          '	gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + ' +
+          '									 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + ' +
+          '									 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + ' +
+          '									 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + ' +
+          '									 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );' +
+          '}'
     })
   },
 })

--- a/src/postprocessing/UnrealBloomPass.js
+++ b/src/postprocessing/UnrealBloomPass.js
@@ -284,36 +284,38 @@ UnrealBloomPass.prototype = Object.assign(Object.create(Pass.prototype), {
         direction: { value: new Vector2(0.5, 0.5) },
       },
 
-      vertexShader: 'varying vec2 vUv;\n' +
-          'void main() {\n' +
-          '	vUv = uv;\n' +
-          '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
-          '}',
-      fragmentShader: '#include <common>' +
-          'varying vec2 vUv;\n' +
-          'uniform sampler2D colorTexture;\n' +
-          'uniform vec2 texSize;' +
-          'uniform vec2 direction;' +
-          '\n' +
-          'float gaussianPdf(in float x, in float sigma) {' +
-          '	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;' +
-          '}' +
-          'void main() {\n' +
-          '	vec2 invSize = 1.0 / texSize;' +
-          '	float fSigma = float(SIGMA);' +
-          '	float weightSum = gaussianPdf(0.0, fSigma);' +
-          '	vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;' +
-          '	for( int i = 1; i < KERNEL_RADIUS; i ++ ) {' +
-          '		float x = float(i);' +
-          '		float w = gaussianPdf(x, fSigma);' +
-          '		vec2 uvOffset = direction * invSize * x;' +
-          '		vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;' +
-          '		vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;' +
-          '		diffuseSum += (sample1 + sample2) * w;' +
-          '		weightSum += 2.0 * w;' +
-          '	}' +
-          '	gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n' +
-          '}'
+      vertexShader:
+        'varying vec2 vUv;\n' +
+        'void main() {\n' +
+        '	vUv = uv;\n' +
+        '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
+        '}',
+      fragmentShader:
+        '#include <common>' +
+        'varying vec2 vUv;\n' +
+        'uniform sampler2D colorTexture;\n' +
+        'uniform vec2 texSize;' +
+        'uniform vec2 direction;' +
+        '\n' +
+        'float gaussianPdf(in float x, in float sigma) {' +
+        '	return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;' +
+        '}' +
+        'void main() {\n' +
+        '	vec2 invSize = 1.0 / texSize;' +
+        '	float fSigma = float(SIGMA);' +
+        '	float weightSum = gaussianPdf(0.0, fSigma);' +
+        '	vec3 diffuseSum = texture2D( colorTexture, vUv).rgb * weightSum;' +
+        '	for( int i = 1; i < KERNEL_RADIUS; i ++ ) {' +
+        '		float x = float(i);' +
+        '		float w = gaussianPdf(x, fSigma);' +
+        '		vec2 uvOffset = direction * invSize * x;' +
+        '		vec3 sample1 = texture2D( colorTexture, vUv + uvOffset).rgb;' +
+        '		vec3 sample2 = texture2D( colorTexture, vUv - uvOffset).rgb;' +
+        '		diffuseSum += (sample1 + sample2) * w;' +
+        '		weightSum += 2.0 * w;' +
+        '	}' +
+        '	gl_FragColor = vec4(diffuseSum/weightSum, 1.0);\n' +
+        '}',
     })
   },
 
@@ -336,35 +338,37 @@ UnrealBloomPass.prototype = Object.assign(Object.create(Pass.prototype), {
         bloomRadius: { value: 0.0 },
       },
 
-      vertexShader: 'varying vec2 vUv;\n' +
-          'void main() {\n' +
-          '	vUv = uv;\n' +
-          '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
-          '}',
-      fragmentShader: 'varying vec2 vUv;' +
-          'uniform sampler2D blurTexture1;' +
-          'uniform sampler2D blurTexture2;' +
-          'uniform sampler2D blurTexture3;' +
-          'uniform sampler2D blurTexture4;' +
-          'uniform sampler2D blurTexture5;' +
-          'uniform sampler2D dirtTexture;' +
-          'uniform float bloomStrength;' +
-          'uniform float bloomRadius;' +
-          'uniform float bloomFactors[NUM_MIPS];' +
-          'uniform vec3 bloomTintColors[NUM_MIPS];' +
-          '' +
-          'float lerpBloomFactor(const in float factor) { ' +
-          '	float mirrorFactor = 1.2 - factor;' +
-          '	return mix(factor, mirrorFactor, bloomRadius);' +
-          '}' +
-          '' +
-          'void main() {' +
-          '	gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + ' +
-          '									 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + ' +
-          '									 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + ' +
-          '									 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + ' +
-          '									 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );' +
-          '}'
+      vertexShader:
+        'varying vec2 vUv;\n' +
+        'void main() {\n' +
+        '	vUv = uv;\n' +
+        '	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n' +
+        '}',
+      fragmentShader:
+        'varying vec2 vUv;' +
+        'uniform sampler2D blurTexture1;' +
+        'uniform sampler2D blurTexture2;' +
+        'uniform sampler2D blurTexture3;' +
+        'uniform sampler2D blurTexture4;' +
+        'uniform sampler2D blurTexture5;' +
+        'uniform sampler2D dirtTexture;' +
+        'uniform float bloomStrength;' +
+        'uniform float bloomRadius;' +
+        'uniform float bloomFactors[NUM_MIPS];' +
+        'uniform vec3 bloomTintColors[NUM_MIPS];' +
+        '' +
+        'float lerpBloomFactor(const in float factor) { ' +
+        '	float mirrorFactor = 1.2 - factor;' +
+        '	return mix(factor, mirrorFactor, bloomRadius);' +
+        '}' +
+        '' +
+        'void main() {' +
+        '	gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) + ' +
+        '									 lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) + ' +
+        '									 lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) + ' +
+        '									 lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) + ' +
+        '									 lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );' +
+        '}',
     })
   },
 })


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Following the fix for issue #207 the google closure compiler gives a warning about backslash line continuation. 
https://google.github.io/styleguide/jsguide.html#features-strings-no-line-continuations

### What

<!-- what have you done, if its a bug, whats your solution? -->

It is not a bug, but it could easily lead to a bug in the future if left alone. A space after a backslash line continuation can cause strange issues.

I removed all the backslashes and replaced them with ' + instead.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged


After my changes the google closure compiler no longer gives warnings about this, but I am not sure if this change has any adverse effects on the codebase, though it shouldn't be a problem.

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
