### PR TITLE
fix: convert CSS2DRenderer to ES6, use new matrix flags

### DIFF
--- a/src/renderers/CSS2DRenderer.js
+++ b/src/renderers/CSS2DRenderer.js
@@ -62,8 +62,9 @@ class CSS2DRenderer {
     }
 
     this.render = function (scene, camera) {
-      if (scene.matrixWorldAutoUpdate === true) scene.updateMatrixWorld()
-      if (camera.parent === null && camera.matrixWorldAutoUpdate === true) camera.updateMatrixWorld()
+      if (scene.matrixWorldAutoUpdate === true || scene.autoUpdate === true) scene.updateMatrixWorld()
+      if (camera.parent === null && (camera.matrixWorldAutoUpdate == null || camera.matrixWorldAutoUpdate === true))
+        camera.updateMatrixWorld()
 
       _viewMatrix.copy(camera.matrixWorldInverse)
       _viewProjectionMatrix.multiplyMatrices(camera.projectionMatrix, _viewMatrix)

--- a/src/renderers/CSS2DRenderer.js
+++ b/src/renderers/CSS2DRenderer.js
@@ -1,153 +1,163 @@
 import { Matrix4, Object3D, Vector3 } from 'three'
 
-var CSS2DObject = function (element) {
-  Object3D.call(this)
+class CSS2DObject extends Object3D {
+  constructor(element = document.createElement('div')) {
+    super()
 
-  this.element = element || document.createElement('div')
+    this.isCSS2DObject = true
 
-  this.element.style.position = 'absolute'
+    this.element = element
 
-  this.addEventListener('removed', function () {
-    this.traverse(function (object) {
-      if (object.element instanceof Element && object.element.parentNode !== null) {
-        object.element.parentNode.removeChild(object.element)
-      }
+    this.element.style.position = 'absolute'
+    this.element.style.userSelect = 'none'
+
+    this.element.setAttribute('draggable', false)
+
+    this.addEventListener('removed', function () {
+      this.traverse(function (object) {
+        if (object.element instanceof Element && object.element.parentNode !== null) {
+          object.element.parentNode.removeChild(object.element)
+        }
+      })
     })
-  })
-}
+  }
 
-CSS2DObject.prototype = Object.assign(Object.create(Object3D.prototype), {
-  constructor: CSS2DObject,
-
-  copy: function (source, recursive) {
-    Object3D.prototype.copy.call(this, source, recursive)
+  copy(source, recursive) {
+    super.copy(source, recursive)
 
     this.element = source.element.cloneNode(true)
 
     return this
-  },
-})
-
-//
-
-var CSS2DRenderer = function () {
-  var _this = this
-
-  var _width, _height
-  var _widthHalf, _heightHalf
-
-  var vector = new Vector3()
-  var viewMatrix = new Matrix4()
-  var viewProjectionMatrix = new Matrix4()
-
-  var cache = {
-    objects: new WeakMap(),
   }
+}
 
-  var domElement = document.createElement('div')
-  domElement.style.overflow = 'hidden'
+const _vector = /*#__PURE__*/ new Vector3()
+const _viewMatrix = /*#__PURE__*/ new Matrix4()
+const _viewProjectionMatrix = /*#__PURE__*/ new Matrix4()
+const _a = /*#__PURE__*/ new Vector3()
+const _b = /*#__PURE__*/ new Vector3()
 
-  this.domElement = domElement
+class CSS2DRenderer {
+  constructor(parameters = {}) {
+    const _this = this
 
-  this.getSize = function () {
-    return {
-      width: _width,
-      height: _height,
+    let _width, _height
+    let _widthHalf, _heightHalf
+
+    const cache = {
+      objects: new WeakMap(),
     }
-  }
 
-  this.setSize = function (width, height) {
-    _width = width
-    _height = height
+    const domElement = parameters.element !== undefined ? parameters.element : document.createElement('div')
 
-    _widthHalf = _width / 2
-    _heightHalf = _height / 2
+    domElement.style.overflow = 'hidden'
 
-    domElement.style.width = width + 'px'
-    domElement.style.height = height + 'px'
-  }
+    this.domElement = domElement
 
-  var renderObject = function (object, scene, camera) {
-    if (object instanceof CSS2DObject) {
-      object.onBeforeRender(_this, scene, camera)
+    this.getSize = function () {
+      return {
+        width: _width,
+        height: _height,
+      }
+    }
 
-      vector.setFromMatrixPosition(object.matrixWorld)
-      vector.applyMatrix4(viewProjectionMatrix)
+    this.render = function (scene, camera) {
+      if (scene.matrixWorldAutoUpdate === true) scene.updateMatrixWorld()
+      if (camera.parent === null && camera.matrixWorldAutoUpdate === true) camera.updateMatrixWorld()
 
-      var element = object.element
+      _viewMatrix.copy(camera.matrixWorldInverse)
+      _viewProjectionMatrix.multiplyMatrices(camera.projectionMatrix, _viewMatrix)
 
-      element.style.transform =
-        'translate(-50%,-50%) translate(' +
-        (vector.x * _widthHalf + _widthHalf) +
-        'px,' +
-        (-vector.y * _heightHalf + _heightHalf) +
-        'px)'
-      element.style.display = object.visible && vector.z >= -1 && vector.z <= 1 ? '' : 'none'
+      renderObject(scene, scene, camera)
+      zOrder(scene)
+    }
 
-      var objectData = {
-        distanceToCameraSquared: getDistanceToSquared(camera, object),
+    this.setSize = function (width, height) {
+      _width = width
+      _height = height
+
+      _widthHalf = _width / 2
+      _heightHalf = _height / 2
+
+      domElement.style.width = width + 'px'
+      domElement.style.height = height + 'px'
+    }
+
+    function renderObject(object, scene, camera) {
+      if (object.isCSS2DObject) {
+        _vector.setFromMatrixPosition(object.matrixWorld)
+        _vector.applyMatrix4(_viewProjectionMatrix)
+
+        const visible =
+          object.visible === true && _vector.z >= -1 && _vector.z <= 1 && object.layers.test(camera.layers) === true
+        object.element.style.display = visible === true ? '' : 'none'
+
+        if (visible === true) {
+          object.onBeforeRender(_this, scene, camera)
+
+          const element = object.element
+
+          element.style.transform =
+            'translate(-50%,-50%) translate(' +
+            (_vector.x * _widthHalf + _widthHalf) +
+            'px,' +
+            (-_vector.y * _heightHalf + _heightHalf) +
+            'px)'
+
+          if (element.parentNode !== domElement) {
+            domElement.appendChild(element)
+          }
+
+          object.onAfterRender(_this, scene, camera)
+        }
+
+        const objectData = {
+          distanceToCameraSquared: getDistanceToSquared(camera, object),
+        }
+
+        cache.objects.set(object, objectData)
       }
 
-      cache.objects.set(object, objectData)
-
-      if (element.parentNode !== domElement) {
-        domElement.appendChild(element)
+      for (let i = 0, l = object.children.length; i < l; i++) {
+        renderObject(object.children[i], scene, camera)
       }
-
-      object.onAfterRender(_this, scene, camera)
     }
 
-    for (let i = 0, l = object.children.length; i < l; i++) {
-      renderObject(object.children[i], scene, camera)
+    function getDistanceToSquared(object1, object2) {
+      _a.setFromMatrixPosition(object1.matrixWorld)
+      _b.setFromMatrixPosition(object2.matrixWorld)
+
+      return _a.distanceToSquared(_b)
     }
-  }
 
-  var getDistanceToSquared = (function () {
-    var a = new Vector3()
-    var b = new Vector3()
+    function filterAndFlatten(scene) {
+      const result = []
 
-    return function (object1, object2) {
-      a.setFromMatrixPosition(object1.matrixWorld)
-      b.setFromMatrixPosition(object2.matrixWorld)
+      scene.traverse(function (object) {
+        if (object.isCSS2DObject) result.push(object)
+      })
 
-      return a.distanceToSquared(b)
+      return result
     }
-  })()
 
-  var filterAndFlatten = function (scene) {
-    var result = []
+    function zOrder(scene) {
+      const sorted = filterAndFlatten(scene).sort(function (a, b) {
+        if (a.renderOrder !== b.renderOrder) {
+          return b.renderOrder - a.renderOrder
+        }
 
-    scene.traverse(function (object) {
-      if (object instanceof CSS2DObject) result.push(object)
-    })
+        const distanceA = cache.objects.get(a).distanceToCameraSquared
+        const distanceB = cache.objects.get(b).distanceToCameraSquared
 
-    return result
-  }
+        return distanceA - distanceB
+      })
 
-  var zOrder = function (scene) {
-    var sorted = filterAndFlatten(scene).sort(function (a, b) {
-      var distanceA = cache.objects.get(a).distanceToCameraSquared
-      var distanceB = cache.objects.get(b).distanceToCameraSquared
+      const zMax = sorted.length
 
-      return distanceA - distanceB
-    })
-
-    var zMax = sorted.length
-
-    for (let i = 0, l = sorted.length; i < l; i++) {
-      sorted[i].element.style.zIndex = zMax - i
+      for (let i = 0, l = sorted.length; i < l; i++) {
+        sorted[i].element.style.zIndex = zMax - i
+      }
     }
-  }
-
-  this.render = function (scene, camera) {
-    if (scene.autoUpdate === true) scene.updateMatrixWorld()
-    if (camera.parent === null) camera.updateMatrixWorld()
-
-    viewMatrix.copy(camera.matrixWorldInverse)
-    viewProjectionMatrix.multiplyMatrices(camera.projectionMatrix, viewMatrix)
-
-    renderObject(scene, scene, camera)
-    zOrder(scene)
   }
 }
 


### PR DESCRIPTION
Fixes #212 and adds backwards compat for https://github.com/mrdoob/three.js/pull/24028.