### PR TITLE
fix: createControllerModel now unsubscribes from controller group events

### DIFF
--- a/src/webxr/XRControllerModelFactory.ts
+++ b/src/webxr/XRControllerModelFactory.ts
@@ -169,7 +169,7 @@ class XRControllerModelFactory {
     const controllerModel = new XRControllerModel()
     let scene: Object3D | null = null
 
-    controller.addEventListener('connected', (event) => {
+    const onConnected = (event: any): void => {
       const xrInputSource = event.data
 
       if (xrInputSource.targetRayMode !== 'tracked-pointer' || !xrInputSource.gamepad) return
@@ -219,15 +219,21 @@ class XRControllerModelFactory {
         .catch((err) => {
           console.warn(err)
         })
-    })
+    }
 
-    controller.addEventListener('disconnected', () => {
+    controller.addEventListener('connected', onConnected)
+
+    const onDisconnected = (): void => {
+      controller.removeEventListener('connected', onConnected)
+      controller.removeEventListener('disconnected', onDisconnected)
       controllerModel.motionController = null
       if (scene) {
         controllerModel.remove(scene)
       }
       scene = null
-    })
+    }
+
+    controller.addEventListener('disconnected', onDisconnected)
 
     return controllerModel
   }


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

It triggered a bug when controller were disconnecting (say from switching to hands or losing them). Controller group usually stayed the same but createControllerModel were called on each mount thus creating multiple listeners
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
createControllerModel now properly unsubscribes from controller group events

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
