### PR TITLE
Fix endOfLine error on Windows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "all",
   "singleQuote": true,
   "tabWidth": 2,
-  "printWidth": 120
+  "printWidth": 120,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
This small change makes prettier not complain when opening CRLF files on Windows.