### PR TITLE
fix: mouseButtons and touches allow undefined in OrbitControls

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -67,13 +67,20 @@ class OrbitControls extends EventDispatcher {
   // The four arrow keys
   keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' }
   // Mouse buttons
-  mouseButtons = {
+  mouseButtons: Partial<{
+    LEFT: MOUSE
+    MIDDLE: MOUSE
+    RIGHT: MOUSE
+  }> = {
     LEFT: MOUSE.ROTATE,
     MIDDLE: MOUSE.DOLLY,
     RIGHT: MOUSE.PAN,
   }
   // Touch fingers
-  touches = { ONE: TOUCH.ROTATE, TWO: TOUCH.DOLLY_PAN }
+  touches: Partial<{
+    ONE: TOUCH
+    TWO: TOUCH
+  }> = { ONE: TOUCH.ROTATE, TWO: TOUCH.DOLLY_PAN }
   target0: Vector3
   position0: Vector3
   zoom0: number


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

resolves: https://github.com/pmndrs/three-stdlib/issues/219

In three.js , it sets state to none if the switch case does not match any MOUSE enum.
https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/OrbitControls.js#L984

It would be nice to be able to omit the `mouseButtons` or `touches` elements.

### What

<!-- what have you done, if its a bug, whats your solution? -->

Add Partial to `mouseButtons` and `touches` types in `OrbitControls`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

Thanks for the great package.