### PR TITLE
fix: colorSpace <=> encoding fallback

### DIFF
--- a/src/interactive/HTMLMesh.js
+++ b/src/interactive/HTMLMesh.js
@@ -1,4 +1,4 @@
-import { CanvasTexture, LinearFilter, Mesh, MeshBasicMaterial, PlaneGeometry, sRGBEncoding, Color } from 'three'
+import { CanvasTexture, LinearFilter, Mesh, MeshBasicMaterial, PlaneGeometry, Color } from 'three'
 
 class HTMLMesh extends Mesh {
   constructor(dom) {
@@ -41,7 +41,8 @@ class HTMLTexture extends CanvasTexture {
     this.dom = dom
 
     this.anisotropy = 16
-    this.encoding = sRGBEncoding
+    if ('colorSpace' in this) this.colorSpace = 'srgb'
+    else this.encoding = 3001 // sRGBEncoding
     this.minFilter = LinearFilter
     this.magFilter = LinearFilter
 

--- a/src/lights/LightProbeGenerator.js
+++ b/src/lights/LightProbeGenerator.js
@@ -1,4 +1,4 @@
-import { Color, LightProbe, LinearEncoding, SphericalHarmonics3, Vector3, sRGBEncoding } from 'three'
+import { Color, LightProbe, SphericalHarmonics3, Vector3 } from 'three'
 
 var LightProbeGenerator = {
   // https://www.ppsloan.org/publications/StupidSH36.pdf
@@ -49,7 +49,13 @@ var LightProbeGenerator = {
         color.setRGB(data[i] / 255, data[i + 1] / 255, data[i + 2] / 255)
 
         // convert to linear color space
-        convertColorToLinear(color, cubeTexture.encoding)
+        if ('colorSpace' in cubeTexture) {
+          if (cubeTexture.colorSpace === 'srgb') {
+            color.convertSRGBToLinear()
+          }
+        } else if (cubeTexture.encoding === 3001) { // sRGBEncoding
+color.convertSRGBToLinear()
+        }
 
         // pixel coordinate on unit cube
 
@@ -152,7 +158,13 @@ var LightProbeGenerator = {
         color.setRGB(data[i] / 255, data[i + 1] / 255, data[i + 2] / 255)
 
         // convert to linear color space
-        convertColorToLinear(color, cubeRenderTarget.texture.encoding)
+        if ('colorSpace' in cubeRenderTarget.texture) {
+          if (cubeRenderTarget.texture.colorSpace === 'srgb') {
+            color.convertSRGBToLinear()
+          }
+        } else if (cubeRenderTarget.texture.encoding === 3001) { // sRGBEncoding
+color.convertSRGBToLinear()
+        }
 
         // pixel coordinate on unit cube
 
@@ -222,23 +234,6 @@ var LightProbeGenerator = {
 
     return new LightProbe(sh)
   },
-}
-
-var convertColorToLinear = function (color, encoding) {
-  switch (encoding) {
-    case sRGBEncoding:
-      color.convertSRGBToLinear()
-      break
-
-    case LinearEncoding:
-      break
-
-    default:
-      console.warn('WARNING: LightProbeGenerator convertColorToLinear() encountered an unsupported encoding.')
-      break
-  }
-
-  return color
 }
 
 export { LightProbeGenerator }

--- a/src/lights/LightProbeGenerator.js
+++ b/src/lights/LightProbeGenerator.js
@@ -53,7 +53,8 @@ var LightProbeGenerator = {
           if (cubeTexture.colorSpace === 'srgb') {
             color.convertSRGBToLinear()
           }
-        } else if (cubeTexture.encoding === 3001) { // sRGBEncoding
+        } else if (cubeTexture.encoding === 3001) {
+          // sRGBEncoding
           color.convertSRGBToLinear()
         }
 
@@ -162,7 +163,8 @@ var LightProbeGenerator = {
           if (cubeRenderTarget.texture.colorSpace === 'srgb') {
             color.convertSRGBToLinear()
           }
-        } else if (cubeRenderTarget.texture.encoding === 3001) { // sRGBEncoding
+        } else if (cubeRenderTarget.texture.encoding === 3001) {
+          // sRGBEncoding
           color.convertSRGBToLinear()
         }
 

--- a/src/lights/LightProbeGenerator.js
+++ b/src/lights/LightProbeGenerator.js
@@ -54,7 +54,7 @@ var LightProbeGenerator = {
             color.convertSRGBToLinear()
           }
         } else if (cubeTexture.encoding === 3001) { // sRGBEncoding
-color.convertSRGBToLinear()
+          color.convertSRGBToLinear()
         }
 
         // pixel coordinate on unit cube
@@ -163,7 +163,7 @@ color.convertSRGBToLinear()
             color.convertSRGBToLinear()
           }
         } else if (cubeRenderTarget.texture.encoding === 3001) { // sRGBEncoding
-color.convertSRGBToLinear()
+          color.convertSRGBToLinear()
         }
 
         // pixel coordinate on unit cube

--- a/src/loaders/3MFLoader.js
+++ b/src/loaders/3MFLoader.js
@@ -18,7 +18,6 @@ import {
   NearestFilter,
   RepeatWrapping,
   TextureLoader,
-  sRGBEncoding,
 } from 'three'
 import { unzipSync } from 'fflate'
 
@@ -641,7 +640,8 @@ class ThreeMFLoader extends Loader {
           URL.revokeObjectURL(sourceURI)
         })
 
-        texture.encoding = sRGBEncoding
+        if ('colorSpace' in texture) texture.colorSpace = 'srgb'
+        else texture.encoding = 3001 // sRGBEncoding
 
         // texture parameters
 

--- a/src/loaders/EXRLoader.js
+++ b/src/loaders/EXRLoader.js
@@ -3,7 +3,6 @@ import {
   DataUtils,
   FloatType,
   HalfFloatType,
-  LinearEncoding,
   LinearFilter,
   RedFormat,
   RGBAFormat,
@@ -1791,10 +1790,10 @@ class EXRLoader extends DataTextureLoader {
 
       if (EXRDecoder.outputChannels == 4) {
         EXRDecoder.format = RGBAFormat
-        EXRDecoder.encoding = LinearEncoding
+        EXRDecoder.encoding = 3000 // LinearEncoding
       } else {
         EXRDecoder.format = RedFormat
-        EXRDecoder.encoding = LinearEncoding
+        EXRDecoder.encoding = 3000 // LinearEncoding
       }
 
       return EXRDecoder
@@ -1871,7 +1870,8 @@ class EXRLoader extends DataTextureLoader {
 
   load(url, onLoad, onProgress, onError) {
     function onLoadCallback(texture, texData) {
-      texture.encoding = texData.encoding
+      if ('colorSpace' in texture)  texture.colorSpace = texData.encoding === 3001 ? 'srgb' : 'srgb-linear'
+      else texture.encoding = texData.encoding
       texture.minFilter = LinearFilter
       texture.magFilter = LinearFilter
       texture.generateMipmaps = false

--- a/src/loaders/EXRLoader.js
+++ b/src/loaders/EXRLoader.js
@@ -1,12 +1,4 @@
-import {
-  DataTextureLoader,
-  DataUtils,
-  FloatType,
-  HalfFloatType,
-  LinearFilter,
-  RedFormat,
-  RGBAFormat,
-} from 'three'
+import { DataTextureLoader, DataUtils, FloatType, HalfFloatType, LinearFilter, RedFormat, RGBAFormat } from 'three'
 import { unzlibSync } from 'fflate'
 
 /**
@@ -1870,7 +1862,7 @@ class EXRLoader extends DataTextureLoader {
 
   load(url, onLoad, onProgress, onError) {
     function onLoadCallback(texture, texData) {
-      if ('colorSpace' in texture)  texture.colorSpace = texData.encoding === 3001 ? 'srgb' : 'srgb-linear'
+      if ('colorSpace' in texture) texture.colorSpace = texData.encoding === 3001 ? 'srgb' : 'srgb-linear'
       else texture.encoding = texData.encoding
       texture.minFilter = LinearFilter
       texture.magFilter = LinearFilter

--- a/src/loaders/FBXLoader.js
+++ b/src/loaders/FBXLoader.js
@@ -39,7 +39,6 @@ import {
   Vector3,
   Vector4,
   VectorKeyframeTrack,
-  sRGBEncoding,
 } from 'three'
 import { unzlibSync } from 'fflate'
 import { NURBSCurve } from '../curves/NURBSCurve'
@@ -502,7 +501,8 @@ class FBXTreeParser {
         case 'Maya|TEX_color_map':
           parameters.map = scope.getTexture(textureMap, child.ID)
           if (parameters.map !== undefined) {
-            parameters.map.encoding = sRGBEncoding
+            if ('colorSpace' in parameters.map) parameters.map.colorSpace = 'srgb'
+            else parameters.map.encoding = 3001 // sRGBEncoding
           }
 
           break
@@ -514,7 +514,8 @@ class FBXTreeParser {
         case 'EmissiveColor':
           parameters.emissiveMap = scope.getTexture(textureMap, child.ID)
           if (parameters.emissiveMap !== undefined) {
-            parameters.emissiveMap.encoding = sRGBEncoding
+            if ('colorSpace' in parameters.emissiveMap) parameters.emissiveMap.colorSpace = 'srgb'
+            else parameters.emissiveMap.encoding = 3001 // sRGBEncoding
           }
 
           break
@@ -528,7 +529,9 @@ class FBXTreeParser {
           parameters.envMap = scope.getTexture(textureMap, child.ID)
           if (parameters.envMap !== undefined) {
             parameters.envMap.mapping = EquirectangularReflectionMapping
-            parameters.envMap.encoding = sRGBEncoding
+
+            if ('colorSpace' in parameters.envMap) parameters.envMap.colorSpace = 'srgb'
+            else parameters.envMap.encoding = 3001 // sRGBEncoding
           }
 
           break
@@ -536,7 +539,8 @@ class FBXTreeParser {
         case 'SpecularColor':
           parameters.specularMap = scope.getTexture(textureMap, child.ID)
           if (parameters.specularMap !== undefined) {
-            parameters.specularMap.encoding = sRGBEncoding
+            if ('colorSpace' in parameters.specularMap) parameters.specularMap.colorSpace = 'srgb'
+            else parameters.specularMap.encoding = 3001 // sRGBEncoding
           }
 
           break

--- a/src/loaders/GLTFLoader.js
+++ b/src/loaders/GLTFLoader.js
@@ -60,7 +60,6 @@ import {
   Vector2,
   Vector3,
   VectorKeyframeTrack,
-  sRGBEncoding,
   REVISION,
 } from 'three'
 import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils'
@@ -521,7 +520,7 @@ class GLTFMaterialsUnlitExtension {
       }
 
       if (metallicRoughness.baseColorTexture !== undefined) {
-        pending.push(parser.assignTexture(materialParams, 'map', metallicRoughness.baseColorTexture, sRGBEncoding))
+        pending.push(parser.assignTexture(materialParams, 'map', metallicRoughness.baseColorTexture, 3001)) // sRGBEncoding
       }
     }
 
@@ -731,7 +730,7 @@ class GLTFMaterialsSheenExtension {
     }
 
     if (extension.sheenColorTexture !== undefined) {
-      pending.push(parser.assignTexture(materialParams, 'sheenColorMap', extension.sheenColorTexture, sRGBEncoding))
+      pending.push(parser.assignTexture(materialParams, 'sheenColorMap', extension.sheenColorTexture, 3001)) // sRGBEncoding
     }
 
     if (extension.sheenRoughnessTexture !== undefined) {
@@ -913,7 +912,7 @@ class GLTFMaterialsSpecularExtension {
 
     if (extension.specularColorTexture !== undefined) {
       pending.push(
-        parser.assignTexture(materialParams, 'specularColorMap', extension.specularColorTexture, sRGBEncoding),
+        parser.assignTexture(materialParams, 'specularColorMap', extension.specularColorTexture, 3001), // sRGBEncoding
       )
     }
 
@@ -2515,7 +2514,8 @@ class GLTFParser {
       }
 
       if (encoding !== undefined) {
-        texture.encoding = encoding
+        if ('colorSpace' in texture) texture.colorSpace = encoding === 3001 ? 'srgb' : 'srgb-linear'
+        else texture.encoding = encoding
       }
 
       materialParams[mapName] = texture
@@ -2648,7 +2648,7 @@ class GLTFParser {
       }
 
       if (metallicRoughness.baseColorTexture !== undefined) {
-        pending.push(parser.assignTexture(materialParams, 'map', metallicRoughness.baseColorTexture, sRGBEncoding))
+        pending.push(parser.assignTexture(materialParams, 'map', metallicRoughness.baseColorTexture, 3001)) // sRGBEncoding
       }
 
       materialParams.metalness = metallicRoughness.metallicFactor !== undefined ? metallicRoughness.metallicFactor : 1.0

--- a/src/loaders/HDRCubeTextureLoader.js
+++ b/src/loaders/HDRCubeTextureLoader.js
@@ -1,12 +1,4 @@
-import {
-  CubeTexture,
-  DataTexture,
-  FileLoader,
-  FloatType,
-  HalfFloatType,
-  LinearFilter,
-  Loader,
-} from 'three'
+import { CubeTexture, DataTexture, FileLoader, FloatType, HalfFloatType, LinearFilter, Loader } from 'three'
 import { RGBELoader } from '../loaders/RGBELoader.js'
 
 class HDRCubeTextureLoader extends Loader {

--- a/src/loaders/HDRCubeTextureLoader.js
+++ b/src/loaders/HDRCubeTextureLoader.js
@@ -4,7 +4,6 @@ import {
   FileLoader,
   FloatType,
   HalfFloatType,
-  LinearEncoding,
   LinearFilter,
   Loader,
 } from 'three'
@@ -36,14 +35,9 @@ class HDRCubeTextureLoader extends Loader {
 
     switch (texture.type) {
       case FloatType:
-        texture.encoding = LinearEncoding
-        texture.minFilter = LinearFilter
-        texture.magFilter = LinearFilter
-        texture.generateMipmaps = false
-        break
-
       case HalfFloatType:
-        texture.encoding = LinearEncoding
+        if ('colorSpace' in texture) texture.colorSpace = 'srgb-linear'
+        else texture.encoding = 3000 // LinearEncoding
         texture.minFilter = LinearFilter
         texture.magFilter = LinearFilter
         texture.generateMipmaps = false

--- a/src/loaders/KTX2Loader.js
+++ b/src/loaders/KTX2Loader.js
@@ -19,7 +19,6 @@ import {
   FileLoader,
   FloatType,
   HalfFloatType,
-  LinearEncoding,
   LinearFilter,
   LinearMipmapLinearFilter,
   Loader,
@@ -35,7 +34,6 @@ import {
   RGBA_S3TC_DXT5_Format,
   RGBAFormat,
   RGFormat,
-  sRGBEncoding,
   UnsignedByteType,
 } from 'three'
 import { WorkerPool } from '../utils/WorkerPool.js'
@@ -230,7 +228,8 @@ class KTX2Loader extends Loader {
     texture.magFilter = LinearFilter
     texture.generateMipmaps = false
     texture.needsUpdate = true
-    texture.encoding = dfdTransferFn === KHR_DF_TRANSFER_SRGB ? sRGBEncoding : LinearEncoding
+    if ('colorSpace' in texture) texture.colorSpace = dfdTransferFn === KHR_DF_TRANSFER_SRGB ? 'srgb' : 'srgb-linear'
+    else texture.encoding = dfdTransferFn === KHR_DF_TRANSFER_SRGB ? 3001 : 3000
     texture.premultiplyAlpha = !!(dfdFlags & KHR_DF_FLAG_ALPHA_PREMULTIPLIED)
 
     return texture
@@ -604,9 +603,9 @@ const TYPE_MAP = {
 }
 
 const ENCODING_MAP = {
-  [VK_FORMAT_R8G8B8A8_SRGB]: sRGBEncoding,
-  [VK_FORMAT_R8G8_SRGB]: sRGBEncoding,
-  [VK_FORMAT_R8_SRGB]: sRGBEncoding,
+  [VK_FORMAT_R8G8B8A8_SRGB]: 3001, // sRGBEncoding
+  [VK_FORMAT_R8G8_SRGB]: 3001, // sRGBEncoding
+  [VK_FORMAT_R8_SRGB]: 3001, // sRGBEncoding
 }
 
 async function createDataTexture(container) {
@@ -660,7 +659,7 @@ async function createDataTexture(container) {
 
   texture.type = TYPE_MAP[vkFormat]
   texture.format = FORMAT_MAP[vkFormat]
-  texture.encoding = ENCODING_MAP[vkFormat] || LinearEncoding
+  texture.encoding = ENCODING_MAP[vkFormat] || 3000 // LinearEncoding
 
   texture.needsUpdate = true
 

--- a/src/loaders/RGBELoader.js
+++ b/src/loaders/RGBELoader.js
@@ -1,4 +1,4 @@
-import { DataTextureLoader, DataUtils, FloatType, HalfFloatType, LinearEncoding, LinearFilter } from 'three'
+import { DataTextureLoader, DataUtils, FloatType, HalfFloatType, LinearFilter } from 'three'
 
 // https://github.com/mrdoob/three.js/issues/5552
 // http://en.wikipedia.org/wiki/RGBE_image_format
@@ -355,7 +355,8 @@ class RGBELoader extends DataTextureLoader {
       switch (texture.type) {
         case FloatType:
         case HalfFloatType:
-          texture.encoding = LinearEncoding
+          if ('colorSpace' in texture) texture.colorSpace = 'srgb-linear'
+          else texture.encoding = 3000 // LinearEncoding
           texture.minFilter = LinearFilter
           texture.magFilter = LinearFilter
           texture.generateMipmaps = false

--- a/src/misc/MD2Character.js
+++ b/src/misc/MD2Character.js
@@ -6,7 +6,6 @@ import {
   Object3D,
   TextureLoader,
   UVMapping,
-  sRGBEncoding,
 } from 'three'
 import { MD2Loader } from '../loaders/MD2Loader'
 
@@ -178,7 +177,8 @@ var MD2Character = function () {
       textures[i] = textureLoader.load(baseUrl + textureUrls[i], checkLoadingComplete)
       textures[i].mapping = UVMapping
       textures[i].name = textureUrls[i]
-      textures[i].encoding = sRGBEncoding
+      if ('colorSpace' in textures[i]) textures[i].colorSpace = 'srgb'
+      else textures[i].encoding = 3001 // sRGBEncoding
     }
 
     return textures

--- a/src/misc/MD2Character.js
+++ b/src/misc/MD2Character.js
@@ -1,12 +1,4 @@
-import {
-  AnimationMixer,
-  Box3,
-  Mesh,
-  MeshLambertMaterial,
-  Object3D,
-  TextureLoader,
-  UVMapping,
-} from 'three'
+import { AnimationMixer, Box3, Mesh, MeshLambertMaterial, Object3D, TextureLoader, UVMapping } from 'three'
 import { MD2Loader } from '../loaders/MD2Loader'
 
 var MD2Character = function () {

--- a/src/misc/MD2CharacterComplex.js
+++ b/src/misc/MD2CharacterComplex.js
@@ -1,4 +1,4 @@
-import { Box3, MathUtils, MeshLambertMaterial, Object3D, TextureLoader, UVMapping, sRGBEncoding } from 'three'
+import { Box3, MathUtils, MeshLambertMaterial, Object3D, TextureLoader, UVMapping } from 'three'
 import { MD2Loader } from '../loaders/MD2Loader'
 import { MorphBlendMesh } from '../misc/MorphBlendMesh'
 
@@ -421,7 +421,8 @@ var MD2CharacterComplex = function () {
       textures[i] = textureLoader.load(baseUrl + textureUrls[i], checkLoadingComplete)
       textures[i].mapping = UVMapping
       textures[i].name = textureUrls[i]
-      textures[i].encoding = sRGBEncoding
+      if ('colorSpace' in textures[i]) textures[i].colorSpace = 'srgb'
+      else textures[i].encoding = 3001 // sRGBEncoding
     }
 
     return textures

--- a/src/nodes/core/NodeBuilder.js
+++ b/src/nodes/core/NodeBuilder.js
@@ -6,7 +6,7 @@ import NodeCode from './NodeCode.js'
 import NodeKeywords from './NodeKeywords.js'
 import { NodeUpdateType } from './constants.js'
 
-import { REVISION, LinearEncoding } from 'three'
+import { REVISION } from 'three'
 
 export const shaderStages = ['fragment', 'vertex']
 export const vector = ['x', 'y', 'z', 'w']
@@ -210,11 +210,13 @@ class NodeBuilder {
     let encoding
 
     if (map && map.isTexture) {
-      encoding = map.encoding
+      if ('colorSpace' in map) encoding = map.colorSpace === 'srgb' ? 3001 : 3000
+      else encoding = map.encoding
     } else if (map && map.isWebGLRenderTarget) {
-      encoding = map.texture.encoding
+      if ('colorSpace' in map.texture) encoding = map.texture.colorSpace === 'srgb' ? 3001 : 3000
+      else encoding = map.texture.encoding
     } else {
-      encoding = LinearEncoding
+      encoding = 3000 // LinearEncoding
     }
 
     return encoding

--- a/src/nodes/display/ColorSpaceNode.js
+++ b/src/nodes/display/ColorSpaceNode.js
@@ -1,8 +1,6 @@
 import TempNode from '../core/Node.js'
 import { ShaderNode, vec3, pow, mul, sub, mix, join, lessThanEqual } from '../ShaderNode.js'
 
-import { LinearEncoding, sRGBEncoding } from 'three'
-
 export const LinearToLinear = new ShaderNode((inputs) => {
   return inputs.value
 })
@@ -41,9 +39,9 @@ class ColorSpaceNode extends TempNode {
   fromEncoding(encoding) {
     let method = null
 
-    if (encoding === LinearEncoding) {
+    if (encoding === 3000) {
       method = 'Linear'
-    } else if (encoding === sRGBEncoding) {
+    } else if (encoding === 3001) {
       method = 'sRGB'
     }
 

--- a/src/objects/Reflector.js
+++ b/src/objects/Reflector.js
@@ -126,7 +126,8 @@ class Reflector extends Mesh {
 
       // Render
 
-      renderTarget.texture.encoding = renderer.outputEncoding
+      if ('colorSpace' in renderTarget.texture) renderTarget.texture.colorSpace = renderer.outputColorSpace
+      else renderTarget.texture.encoding = renderer.outputEncoding
 
       scope.visible = false
 

--- a/src/objects/ReflectorForSSRPass.js
+++ b/src/objects/ReflectorForSSRPass.js
@@ -177,7 +177,8 @@ class ReflectorForSSRPass extends Mesh {
 
       // Render
 
-      renderTarget.texture.encoding = renderer.outputEncoding
+      if ('colorSpace' in renderTarget.texture) renderTarget.texture.colorSpace = renderer.outputColorSpace
+      else renderTarget.texture.encoding = renderer.outputEncoding
 
       // scope.visible = false;
 

--- a/src/objects/Refractor.js
+++ b/src/objects/Refractor.js
@@ -193,7 +193,8 @@ class Refractor extends Mesh {
     this.onBeforeRender = function (renderer, scene, camera) {
       // Render
 
-      renderTarget.texture.encoding = renderer.outputEncoding
+      if ('colorSpace' in renderTarget.texture) renderTarget.texture.colorSpace = renderer.outputColorSpace
+      else renderTarget.texture.encoding = renderer.outputEncoding
 
       // ensure refractors are rendered only once per frame
 

--- a/src/objects/Water2.js
+++ b/src/objects/Water2.js
@@ -1,7 +1,6 @@
 import {
   Clock,
   Color,
-  LinearEncoding,
   Matrix4,
   Mesh,
   RepeatWrapping,
@@ -39,7 +38,7 @@ class Water2 extends Mesh {
     const reflectivity = options.reflectivity || 0.02
     const scale = options.scale || 1
     const shader = options.shader || Water2.WaterShader
-    const encoding = options.encoding !== undefined ? options.encoding : LinearEncoding
+    const encoding = options.encoding !== undefined ? options.encoding : 3000
 
     const textureLoader = new TextureLoader()
 

--- a/src/postprocessing/SSRPass.js
+++ b/src/postprocessing/SSRPass.js
@@ -348,7 +348,10 @@ SSRPass.prototype = Object.assign(Object.create(Pass.prototype), {
   render: function (renderer, writeBuffer /*, readBuffer, deltaTime, maskActive */) {
     // render beauty and depth
 
-    if (this.encoding) this.beautyRenderTarget.texture.encoding = this.encoding
+    if (this.encoding) {
+      if ('colorSpace' in this.beautyRenderTarget.texture) this.beautyRenderTarget.texture.colorSpace = this.encoding === 3001 ? 'srgb' : 'srgb-linear'
+      else this.beautyRenderTarget.texture.encoding = this.encoding
+    }
     renderer.setRenderTarget(this.beautyRenderTarget)
     renderer.clear()
     if (this.groundReflector) {

--- a/src/postprocessing/SSRPass.js
+++ b/src/postprocessing/SSRPass.js
@@ -349,7 +349,8 @@ SSRPass.prototype = Object.assign(Object.create(Pass.prototype), {
     // render beauty and depth
 
     if (this.encoding) {
-      if ('colorSpace' in this.beautyRenderTarget.texture) this.beautyRenderTarget.texture.colorSpace = this.encoding === 3001 ? 'srgb' : 'srgb-linear'
+      if ('colorSpace' in this.beautyRenderTarget.texture)
+        this.beautyRenderTarget.texture.colorSpace = this.encoding === 3001 ? 'srgb' : 'srgb-linear'
       else this.beautyRenderTarget.texture.encoding = this.encoding
     }
     renderer.setRenderTarget(this.beautyRenderTarget)

--- a/src/renderers/webgpu/WebGPUTextures.js
+++ b/src/renderers/webgpu/WebGPUTextures.js
@@ -17,7 +17,6 @@ import {
   UnsignedByteType,
   FloatType,
   HalfFloatType,
-  sRGBEncoding,
 } from 'three'
 import WebGPUTextureUtils from './WebGPUTextureUtils'
 
@@ -474,27 +473,27 @@ class WebGPUTextures {
   _getFormat(texture) {
     const format = texture.format
     const type = texture.type
-    const encoding = texture.encoding
+    const isSRGB = 'colorSpace' in texture ? texture.colorSpace === 'srgb' : texture.encoding === 3001
 
     let formatGPU
 
     switch (format) {
       case RGBA_S3TC_DXT1_Format:
-        formatGPU = encoding === sRGBEncoding ? GPUTextureFormat.BC1RGBAUnormSRGB : GPUTextureFormat.BC1RGBAUnorm
+        formatGPU = isSRGB ? GPUTextureFormat.BC1RGBAUnormSRGB : GPUTextureFormat.BC1RGBAUnorm
         break
 
       case RGBA_S3TC_DXT3_Format:
-        formatGPU = encoding === sRGBEncoding ? GPUTextureFormat.BC2RGBAUnormSRGB : GPUTextureFormat.BC2RGBAUnorm
+        formatGPU = isSRGB ? GPUTextureFormat.BC2RGBAUnormSRGB : GPUTextureFormat.BC2RGBAUnorm
         break
 
       case RGBA_S3TC_DXT5_Format:
-        formatGPU = encoding === sRGBEncoding ? GPUTextureFormat.BC3RGBAUnormSRGB : GPUTextureFormat.BC3RGBAUnorm
+        formatGPU = isSRGB ? GPUTextureFormat.BC3RGBAUnormSRGB : GPUTextureFormat.BC3RGBAUnorm
         break
 
       case RGBAFormat:
         switch (type) {
           case UnsignedByteType:
-            formatGPU = encoding === sRGBEncoding ? GPUTextureFormat.RGBA8UnormSRGB : GPUTextureFormat.RGBA8Unorm
+            formatGPU = isSRGB ? GPUTextureFormat.RGBA8UnormSRGB : GPUTextureFormat.RGBA8Unorm
             break
 
           case HalfFloatType:


### PR DESCRIPTION
Fixes #231 by hardcoding legacy encoding constants and rewriting to `colorSpace` and `outputColorSpace` where appropriate.