### PR TITLE
fix: polyfill Data3DTexture

### DIFF
--- a/src/_polyfill/CompressedArrayTexture.js
+++ b/src/_polyfill/CompressedArrayTexture.js
@@ -1,0 +1,12 @@
+import { CompressedTexture, ClampToEdgeWrapping } from 'three'
+
+class CompressedArrayTexture extends CompressedTexture {
+  constructor(mipmaps, width, height, depth, format, type) {
+    super(mipmaps, width, height, format, type)
+    this.isCompressedArrayTexture = true
+    this.image.depth = depth
+    this.wrapR = ClampToEdgeWrapping
+  }
+}
+
+export { CompressedArrayTexture }

--- a/src/_polyfill/Data3DTexture.js
+++ b/src/_polyfill/Data3DTexture.js
@@ -1,0 +1,22 @@
+import { Texture, ClampToEdgeWrapping, NearestFilter } from 'three'
+
+class Data3DTexture extends Texture {
+  constructor(data = null, width = 1, height = 1, depth = 1) {
+    super(null)
+
+    this.isData3DTexture = true
+
+    this.image = { data, width, height, depth }
+
+    this.magFilter = NearestFilter
+    this.minFilter = NearestFilter
+
+    this.wrapR = ClampToEdgeWrapping
+
+    this.generateMipmaps = false
+    this.flipY = false
+    this.unpackAlignment = 1
+  }
+}
+
+export { Data3DTexture }

--- a/src/loaders/KTX2Loader.js
+++ b/src/loaders/KTX2Loader.js
@@ -13,7 +13,6 @@
 
 import {
   CompressedTexture,
-  ClampToEdgeWrapping,
   DataTexture,
   FileLoader,
   FloatType,

--- a/src/loaders/KTX2Loader.js
+++ b/src/loaders/KTX2Loader.js
@@ -14,7 +14,6 @@
 import {
   CompressedTexture,
   ClampToEdgeWrapping,
-  Data3DTexture,
   DataTexture,
   FileLoader,
   FloatType,
@@ -58,16 +57,8 @@ import {
   VK_FORMAT_R8G8B8A8_UNORM,
 } from 'ktx-parse'
 import { ZSTDDecoder } from 'zstddec'
-
-// https://github.com/mrdoob/three.js/pull/24745
-class CompressedArrayTexture extends CompressedTexture {
-  constructor(mipmaps, width, height, depth, format, type) {
-    super(mipmaps, width, height, format, type)
-    this.isCompressedArrayTexture = true
-    this.image.depth = depth
-    this.wrapR = ClampToEdgeWrapping
-  }
-}
+import { CompressedArrayTexture } from '../_polyfill/CompressedArrayTexture'
+import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 const _taskCache = new WeakMap()
 

--- a/src/loaders/LUT3dlLoader.js
+++ b/src/loaders/LUT3dlLoader.js
@@ -4,12 +4,12 @@ import {
   Loader,
   FileLoader,
   DataTexture,
-  Data3DTexture,
   RGBAFormat,
   UnsignedByteType,
   ClampToEdgeWrapping,
   LinearFilter,
 } from 'three'
+import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 export class LUT3dlLoader extends Loader {
   load(url, onLoad, onProgress, onError) {

--- a/src/loaders/LUT3dlLoader.js
+++ b/src/loaders/LUT3dlLoader.js
@@ -1,14 +1,6 @@
 // http://download.autodesk.com/us/systemdocs/help/2011/lustre/index.html?url=./files/WSc4e151a45a3b785a24c3d9a411df9298473-7ffd.htm,topicNumber=d0e9492
 // https://community.foundry.com/discuss/topic/103636/format-spec-for-3dl?mode=Post&postID=895258
-import {
-  Loader,
-  FileLoader,
-  DataTexture,
-  RGBAFormat,
-  UnsignedByteType,
-  ClampToEdgeWrapping,
-  LinearFilter,
-} from 'three'
+import { Loader, FileLoader, DataTexture, RGBAFormat, UnsignedByteType, ClampToEdgeWrapping, LinearFilter } from 'three'
 import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 export class LUT3dlLoader extends Loader {

--- a/src/loaders/LUTCubeLoader.js
+++ b/src/loaders/LUTCubeLoader.js
@@ -1,14 +1,6 @@
 // https://wwwimages2.adobe.com/content/dam/acom/en/products/speedgrade/cc/pdfs/cube-lut-specification-1.0.pdf
 
-import {
-  Loader,
-  FileLoader,
-  Vector3,
-  DataTexture,
-  UnsignedByteType,
-  ClampToEdgeWrapping,
-  LinearFilter,
-} from 'three'
+import { Loader, FileLoader, Vector3, DataTexture, UnsignedByteType, ClampToEdgeWrapping, LinearFilter } from 'three'
 import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 export class LUTCubeLoader extends Loader {

--- a/src/loaders/LUTCubeLoader.js
+++ b/src/loaders/LUTCubeLoader.js
@@ -5,11 +5,11 @@ import {
   FileLoader,
   Vector3,
   DataTexture,
-  Data3DTexture,
   UnsignedByteType,
   ClampToEdgeWrapping,
   LinearFilter,
 } from 'three'
+import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 export class LUTCubeLoader extends Loader {
   load(url, onLoad, onProgress, onError) {

--- a/src/loaders/VOXLoader.js
+++ b/src/loaders/VOXLoader.js
@@ -1,6 +1,5 @@
 import {
   BufferGeometry,
-  Data3DTexture,
   FileLoader,
   Float32BufferAttribute,
   Loader,
@@ -10,6 +9,7 @@ import {
   NearestFilter,
   RedFormat,
 } from 'three'
+import { Data3DTexture } from '../_polyfill/Data3DTexture'
 
 class VOXLoader extends Loader {
   load(url, onLoad, onProgress, onError) {

--- a/src/postprocessing/SSRPass.js
+++ b/src/postprocessing/SSRPass.js
@@ -349,9 +349,11 @@ SSRPass.prototype = Object.assign(Object.create(Pass.prototype), {
     // render beauty and depth
 
     if (this.encoding) {
-      if ('colorSpace' in this.beautyRenderTarget.texture)
+      if ('colorSpace' in this.beautyRenderTarget.texture) {
         this.beautyRenderTarget.texture.colorSpace = this.encoding === 3001 ? 'srgb' : 'srgb-linear'
-      else this.beautyRenderTarget.texture.encoding = this.encoding
+      } else {
+        this.beautyRenderTarget.texture.encoding = this.encoding
+      }
     }
     renderer.setRenderTarget(this.beautyRenderTarget)
     renderer.clear()


### PR DESCRIPTION
Polyfills `Data3DTexture` which was incorrectly consumed from three.js, breaking three < 138.