### PR TITLE
chore: unblock release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,12 +2,7 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    [
-      '@semantic-release/npm',
-      {
-        pkgRoot: './dist',
-      },
-    ],
+    '@semantic-release/npm',
     '@semantic-release/github',
     [
       '@semantic-release/git',


### PR DESCRIPTION
Fixes #239. We now build & publish in place instead of copying over to `dist`.