### PR TITLE
fix(WebGPURenderer): add explicit ext for glslang

### DIFF
--- a/src/renderers/webgpu/WebGPURenderer.js
+++ b/src/renderers/webgpu/WebGPURenderer.js
@@ -169,7 +169,7 @@ class WebGPURenderer {
 
     const device = await adapter.requestDevice(deviceDescriptor)
 
-    const glslang = await import('@webgpu/glslang/dist/web-devel/glslang')
+    const glslang = await import('@webgpu/glslang/dist/web-devel/glslang.js')
     const compiler = await glslang()
 
     const context = parameters.context !== undefined ? parameters.context : this.domElement.getContext('gpupresent')


### PR DESCRIPTION
Fixes #244 by adding a file extension for explicit ESM rules. This will be superseded by #241.