### PR TITLE
fix: don't use Node ext for module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   "files": [
     "dist/*"
   ],
+  "type": "module",
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "sideEffects": false,
   "devDependencies": {
     "@types/three": "^0.128.0",


### PR DESCRIPTION
Fixes #251

Webpack 4 does not understand Node file extensions and is the only bundler to read from `module`. In a future major, we'll be able to utilize `package#exports` so ESM can resolve.