### PR TITLE
fix: remove type=module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "files": [
     "dist/*"
   ],
-  "type": "module",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Removes `type=module` which is breaking CI. We don't need this yet as we don't use `package#exports` and Webpack 4 does not understand Node resolution generally.