### PR TITLE
fix: don't locally increment version

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "node": "18"
+  "node": "18",
+  "packages": ["dist"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "three-stdlib",
-  "version": "2.23.1",
+  "version": "0.0.0-semantic-released",
+  "private": true,
   "description": "stand-alone library of threejs examples",
   "keywords": [
     "three",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   "homepage": "https://github.com/pmndrs/three-stdlib",
   "repository": "https://github.com/pmndrs/three-stdlib",
   "license": "MIT",
-  "files": [
-    "dist/*"
-  ],
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -29,6 +26,7 @@
   "devDependencies": {
     "@types/three": "^0.128.0",
     "copyfiles": "^2.4.1",
+    "json": "^11.0.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "three": "^0.128.0",
@@ -52,7 +50,7 @@
     "three": ">=0.128.0"
   },
   "scripts": {
-    "build": "rimraf dist && vite build && tsc --emitDeclarationOnly && copyfiles -u 1 \"src/**/*.d.ts\" dist",
+    "build": "rimraf dist && vite build && tsc --emitDeclarationOnly && copyfiles -u 1 \"src/**/*.d.ts\" dist && copyfiles package.json dist && json -I -f dist/package.json -e \"this.private=undefined; this.types=\\\"./index.d.ts\\\"; this.main=\\\"./index.cjs\\\"; this.module=\\\"./index.js\\\";\"",
     "lint": "tsc --noEmit"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,12 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/npm',
+    [
+      '@semantic-release/npm',
+      {
+        pkgRoot: './dist',
+      },
+    ],
     '@semantic-release/github',
     [
       '@semantic-release/git',

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,6 +343,11 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+json@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/json/-/json-11.0.0.tgz#2e84493134e2f42c131165aa22a124df38b3a3ee"
+  integrity sha512-N/ITv3Yw9Za8cGxuQqSqrq6RHnlaHWZkAFavcfpH/R52522c26EbihMxnY7A1chxfXJ4d+cEFIsyTgfi9GihrA==
+
 ktx-parse@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.4.5.tgz#79905e22281a9d3e602b2ff522df1ee7d1813aa6"


### PR DESCRIPTION
Adds back `private` to prevent commit spam from version bumps.