### PR TITLE
fix(RenderPixelatedPass ): Types Mismatch

### DIFF
--- a/src/postprocessing/RenderPixelatedPass.d.ts
+++ b/src/postprocessing/RenderPixelatedPass.d.ts
@@ -8,7 +8,13 @@ export interface RenderPixelatedPassParameters {
 }
 
 export class RenderPixelatedPass extends Pass {
-  constructor(pixelSize: number, scene: Scene, camera: Camera, options?: RenderPixelatedPassParameters)
+  constructor(
+    resolution: Vector2,
+    pixelSize: number,
+    scene: Scene,
+    camera: Camera,
+    options?: RenderPixelatedPassParameters,
+  )
   pixelSize: number
   resolution: Vector2
   renderResolution: Vector2
@@ -23,6 +29,6 @@ export class RenderPixelatedPass extends Pass {
   normalEdgeStrength: RenderPixelatedPassParameters['normalEdgeStrength']
   depthEdgeStrength: RenderPixelatedPassParameters['depthEdgeStrength']
 
-  beautyRenderTarget: WebGLRenderTarget
+  rgbRenderTarget: WebGLRenderTarget
   normalRenderTarget: WebGLRenderTarget
 }


### PR DESCRIPTION
Hello,

The type declarations for RenderPixelatedPass does not appear to match the source file.

This PR is a quick manual fix for this. Although, other files may also need their types regenerated.