### PR TITLE
fix(OculusHandPointerModel): cleanup on disconnect, implement dispose

### DIFF
--- a/src/webxr/OculusHandPointerModel.d.ts
+++ b/src/webxr/OculusHandPointerModel.d.ts
@@ -60,4 +60,6 @@ export class OculusHandPointerModel extends Object3D {
   public checkIntersections(objects: Object3D[], recursive?: boolean): void
 
   public setCursor(distance: number): void
+
+  public dispose(): void
 }

--- a/src/webxr/OculusHandPointerModel.js
+++ b/src/webxr/OculusHandPointerModel.js
@@ -25,9 +25,10 @@ class OculusHandPointerModel extends THREE.Object3D {
 
     this.hand = hand
     this.controller = controller
+
+    // Unused
     this.motionController = null
     this.envMap = null
-
     this.mesh = null
 
     this.pointerGeometry = null
@@ -41,15 +42,30 @@ class OculusHandPointerModel extends THREE.Object3D {
 
     this.raycaster = null
 
-    hand.addEventListener('connected', (event) => {
-      const xrInputSource = event.data
-      if (xrInputSource.hand) {
-        this.visible = true
-        this.xrInputSource = xrInputSource
+    this._onConnected = this._onConnected.bind(this)
+    this._onDisconnected = this._onDisconnected.bind(this)
+    this.hand.addEventListener('connected', this._onConnected)
+    this.hand.addEventListener('disconnect', this._onDisconnected)
+  }
 
-        this.createPointer()
-      }
-    })
+  _onConnected(event) {
+    const xrInputSource = event.data
+    if (xrInputSource.hand) {
+      this.visible = true
+      this.xrInputSource = xrInputSource
+
+      this.createPointer()
+    }
+  }
+
+  _onDisconnected() {
+    this.visible = false
+    this.xrInputSource = null
+
+    this.pointerGeometry.dispose()
+    this.pointerMesh.material.dispose()
+
+    this.clear()
   }
 
   _drawVerticesRing(vertices, baseVector, ringIndex) {
@@ -254,6 +270,12 @@ class OculusHandPointerModel extends THREE.Object3D {
     if (this.raycaster && !this.attached) {
       this.cursorObject.position.copy(direction.multiplyScalar(distance))
     }
+  }
+
+  dispose() {
+    this._onDisconnected()
+    this.hand.removeEventListener('connected', this._onConnected)
+    this.hand.removeEventListener('disconnect', this._onDisconnected)
   }
 }
 

--- a/src/webxr/OculusHandPointerModel.js
+++ b/src/webxr/OculusHandPointerModel.js
@@ -45,7 +45,7 @@ class OculusHandPointerModel extends THREE.Object3D {
     this._onConnected = this._onConnected.bind(this)
     this._onDisconnected = this._onDisconnected.bind(this)
     this.hand.addEventListener('connected', this._onConnected)
-    this.hand.addEventListener('disconnect', this._onDisconnected)
+    this.hand.addEventListener('disconnected', this._onDisconnected)
   }
 
   _onConnected(event) {

--- a/src/webxr/OculusHandPointerModel.js
+++ b/src/webxr/OculusHandPointerModel.js
@@ -275,7 +275,7 @@ class OculusHandPointerModel extends THREE.Object3D {
   dispose() {
     this._onDisconnected()
     this.hand.removeEventListener('connected', this._onConnected)
-    this.hand.removeEventListener('disconnect', this._onDisconnected)
+    this.hand.removeEventListener('disconnected', this._onDisconnected)
   }
 }
 


### PR DESCRIPTION
Fixes an issue in `OculusHandPointerModel` where it would repeatedly create cursors on input change and create a memory leak. Additionally, I've implemented `dispose` to cleanup its listeners and to match the other WebXR classes.