### PR TITLE
fix(utils): `toCreasedNormals()`: call `toNonIndexed()` only on indexed geometries (#268)

### DIFF
--- a/src/utils/BufferGeometryUtils.ts
+++ b/src/utils/BufferGeometryUtils.ts
@@ -844,13 +844,26 @@ export function computeMorphedAttributes(object: Mesh | Line | Points): Computed
   }
 }
 
-// Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at
-// an angle greater than the crease angle.
+/**
+ * Modifies the supplied geometry if it is non-indexed, otherwise creates a new,
+ * non-indexed geometry. Returns the geometry with smooth normals everywhere except
+ * faces that meet at an angle greater than the crease angle.
+ *
+ * Backwards compatible with code such as @react-three/drei's `<RoundedBox>`
+ * which uses this method to operate on the original geometry.
+ *
+ * As of this writing, BufferGeometry.toNonIndexed() warns if the geometry is
+ * non-indexed and returns `this`, i.e. the same geometry on which it was called:
+ * `BufferGeometry is already non-indexed.`
+ *
+ * @param geometry
+ * @param creaseAngle
+ */
 export function toCreasedNormals(geometry: BufferGeometry, creaseAngle = Math.PI / 3 /* 60 degrees */): BufferGeometry {
   const creaseDot = Math.cos(creaseAngle)
   const hashMultiplier = (1 + 1e-10) * 1e2
 
-  // reusable vertors
+  // reusable vectors
   const verts = [new Vector3(), new Vector3(), new Vector3()]
   const tempVec1 = new Vector3()
   const tempVec2 = new Vector3()
@@ -865,7 +878,7 @@ export function toCreasedNormals(geometry: BufferGeometry, creaseAngle = Math.PI
     return `${x},${y},${z}`
   }
 
-  const resultGeometry = geometry.toNonIndexed()
+  const resultGeometry = geometry.index ? geometry.toNonIndexed() : geometry
   const posAttr = resultGeometry.attributes.position
   const vertexMap: { [key: string]: Vector3[] } = {}
 


### PR DESCRIPTION
### Why

`BufferGeometryUtils.toCreasedNormals()` produces a warning by `BufferGeometry.toNonIndexed()` if the provided geometry is already non-indexed:

```
THREE.BufferGeometry.toNonIndexed(): BufferGeometry is already non-indexed.
```

It should not produce the warning.

resolves #268

### What

This changes `BufferGeometryUtils.toCreasedNormals()` to call `BufferGeometry.toNonIndexed()` only if the provided geometry is indexed.
Otherwise, it will just use the original geometry, as has been the case before:
`BufferGeometry.toNonIndexed()` returns `this` if the geometry is non-indexed.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
