### PR TITLE
fix(OculusHandPointerModel): safely dispose pointer mesh

### DIFF
--- a/src/webxr/OculusHandPointerModel.js
+++ b/src/webxr/OculusHandPointerModel.js
@@ -62,8 +62,8 @@ class OculusHandPointerModel extends THREE.Object3D {
     this.visible = false
     this.xrInputSource = null
 
-    this.pointerGeometry.dispose()
-    this.pointerMesh.material.dispose()
+    this.pointerGeometry?.dispose()
+    this.pointerMesh?.material.dispose()
 
     this.clear()
   }


### PR DESCRIPTION
Mirrors https://github.com/mrdoob/three.js/pull/26387.