### PR TITLE
fix(OrbitControls): update camera up direction

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -199,6 +199,10 @@ class OrbitControls extends EventDispatcher {
       return function update(): boolean {
         const position = scope.object.position
 
+        // update new up direction
+        quat.setFromUnitVectors(object.up, new Vector3(0, 1, 0))
+        quatInverse.copy(quat).invert()
+
         offset.copy(position).sub(scope.target)
 
         // rotate offset to "y-axis-is-up" space
@@ -986,4 +990,5 @@ class MapControls extends OrbitControls {
   }
 }
 
-export { OrbitControls, MapControls }
+export { MapControls, OrbitControls }
+

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -991,4 +991,4 @@ class MapControls extends OrbitControls {
   }
 }
 
-export { MapControls, OrbitControls }
+export { OrbitControls, MapControls }

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -186,9 +186,10 @@ class OrbitControls extends EventDispatcher {
     // this method is exposed, but perhaps it would be better if we can make it private...
     this.update = ((): (() => void) => {
       const offset = new Vector3()
+      const up = new Vector3(0, 1, 0)
 
       // so camera.up is the orbit axis
-      const quat = new Quaternion().setFromUnitVectors(object.up, new Vector3(0, 1, 0))
+      const quat = new Quaternion().setFromUnitVectors(object.up, up)
       const quatInverse = quat.clone().invert()
 
       const lastPosition = new Vector3()
@@ -200,7 +201,7 @@ class OrbitControls extends EventDispatcher {
         const position = scope.object.position
 
         // update new up direction
-        quat.setFromUnitVectors(object.up, new Vector3(0, 1, 0))
+        quat.setFromUnitVectors(object.up, up)
         quatInverse.copy(quat).invert()
 
         offset.copy(position).sub(scope.target)
@@ -991,4 +992,3 @@ class MapControls extends OrbitControls {
 }
 
 export { MapControls, OrbitControls }
-


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

OrbitControls only follows the object.up orientation on initialization, making it impossible to update if your controls has to follow an object walking around a geometry that's not a plane, such as a character walking around a planet. 

### What

<!-- what have you done, if its a bug, whats your solution? -->

I've added two lines which updates the quat up direction inside the orbitcontrols.update method
This will add two unnecessary operations for most users, though. Perhaps it can be enabled by a flag?

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
