### PR TITLE
feat: support reversing horizontal and vertical orbit separately

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -63,6 +63,8 @@ class OrbitControls extends EventDispatcher {
   autoRotateSpeed = 2.0 // 30 seconds per orbit when fps is 60
   reverseOrbit = false // true if you want to reverse the orbit to mouse drag from left to right = orbits left
   // The four arrow keys
+  reverseHorizontalOrbit = false // true if you want to reverse the horizontal orbit direction
+  reverseVerticalOrbit = false // true if you want to reverse the vertical orbit direction
   keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' }
   // Mouse buttons
   mouseButtons: Partial<{
@@ -398,7 +400,7 @@ class OrbitControls extends EventDispatcher {
     }
 
     function rotateLeft(angle: number): void {
-      if (scope.reverseOrbit) {
+      if (scope.reverseOrbit || scope.reverseHorizontalOrbit) {
         sphericalDelta.theta += angle
       } else {
         sphericalDelta.theta -= angle
@@ -406,7 +408,7 @@ class OrbitControls extends EventDispatcher {
     }
 
     function rotateUp(angle: number): void {
-      if (scope.reverseOrbit) {
+      if (scope.reverseOrbit || scope.reverseVerticalOrbit) {
         sphericalDelta.phi += angle
       } else {
         sphericalDelta.phi -= angle


### PR DESCRIPTION
# Closing in favor of https://github.com/pmndrs/three-stdlib/pull/280
### Why

I'm trying to support drag controls that are different from what OrbitControls ships out of the box. The horizontal drag behaviour is what I want, but the vertical is inverted. Currently, we only have `reverseOrbit`, which enables the vertical drag behaviour that I want but inverts the horizontal as well.

`reverseHorizontalOrbit` is an API that enables inverting just the horizontal orbit direction.
`reverseVerticalOrbit` is an API that enables inverting just the vertical orbit direction.

### What

update `rotateLeft` and `rotateRight` functions in `OrbitControls` to reflect new API.

### Checklist
- [x] Ready to be merged
