### PR TITLE
refactor(GLTFExporter): prefer native Blob/URL methods

### DIFF
--- a/src/exporters/GLTFExporter.js
+++ b/src/exporters/GLTFExporter.js
@@ -527,11 +527,9 @@ class GLTFWriter {
     if (options.binary === true) {
       // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#glb-file-format-specification
 
-      const reader = new FileReader()
-      reader.readAsArrayBuffer(blob)
-      reader.onloadend = function () {
+      blob.arrayBuffer().then((result) => {
         // Binary chunk.
-        const binaryChunk = getPaddedArrayBuffer(reader.result)
+        const binaryChunk = getPaddedArrayBuffer(result)
         const binaryChunkPrefix = new DataView(new ArrayBuffer(GLB_CHUNK_PREFIX_BYTES))
         binaryChunkPrefix.setUint32(0, binaryChunk.byteLength, true)
         binaryChunkPrefix.setUint32(4, GLB_CHUNK_TYPE_BIN, true)
@@ -559,24 +557,14 @@ class GLTFWriter {
           type: 'application/octet-stream',
         })
 
-        const glbReader = new FileReader()
-        glbReader.readAsArrayBuffer(glbBlob)
-        glbReader.onloadend = function () {
-          onDone(glbReader.result)
-        }
-      }
+        glbBlob.arrayBuffer().then(onDone)
+      })
     } else {
       if (json.buffers && json.buffers.length > 0) {
-        const reader = new FileReader()
-        reader.readAsDataURL(blob)
-        reader.onloadend = function () {
-          const base64data = reader.result
-          json.buffers[0].uri = base64data
-          onDone(json)
-        }
-      } else {
-        onDone(json)
+        json.buffers[0].uri = URL.createObjectURL(blob)
       }
+
+      onDone(json)
     }
   }
 
@@ -941,21 +929,17 @@ class GLTFWriter {
 
     if (!json.bufferViews) json.bufferViews = []
 
-    return new Promise(function (resolve) {
-      const reader = new FileReader()
-      reader.readAsArrayBuffer(blob)
-      reader.onloadend = function () {
-        const buffer = getPaddedArrayBuffer(reader.result)
+    return blob.arrayBuffer().then((result) => {
+      const buffer = getPaddedArrayBuffer(result)
 
-        const bufferViewDef = {
-          buffer: writer.processBuffer(buffer),
-          byteOffset: writer.byteOffset,
-          byteLength: buffer.byteLength,
-        }
-
-        writer.byteOffset += buffer.byteLength
-        resolve(json.bufferViews.push(bufferViewDef) - 1)
+      const bufferViewDef = {
+        buffer: writer.processBuffer(buffer),
+        byteOffset: writer.byteOffset,
+        byteLength: buffer.byteLength,
       }
+
+      writer.byteOffset += buffer.byteLength
+      return json.bufferViews.push(bufferViewDef) - 1
     })
   }
 
@@ -1114,11 +1098,9 @@ class GLTFWriter {
           imageDef.uri = canvas.toDataURL(mimeType)
         } else {
           pending.push(
-            getToBlobPromise(canvas, mimeType)
-              .then((blob) => new FileReader().readAsDataURL(blob))
-              .then((dataURL) => {
-                imageDef.uri = dataURL
-              }),
+            getToBlobPromise(canvas, mimeType).then((blob) => {
+              imageDef.uri = URL.createObjectURL(blob)
+            }),
           )
         }
       }

--- a/src/exporters/GLTFExporter.js
+++ b/src/exporters/GLTFExporter.js
@@ -31,9 +31,7 @@ import {
 } from 'three'
 
 async function readAsDataURL(blob) {
-  const url = URL.createObjectURL(blob)
-  const buffer = await fetch(url).then((res) => res.arrayBuffer())
-  URL.revokeObjectURL(url)
+  const buffer = await blob.arrayBuffer()
   const data = btoa(String.fromCharCode(...new Uint8Array(buffer)))
   return `data:${blob.type || ''};base64,${data}`
 }


### PR DESCRIPTION
Resolves #281 by dropping `FileReader.readAsArrayBuffer` and `FileReader.readAsDataURL` for `Blob.arrayBuffer` and `URL.createObjectURL`, respectively.