### PR TITLE
fix: update chevrotain

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/draco3d": "^1.4.0",
     "@types/offscreencanvas": "^2019.6.4",
     "@types/webxr": "^0.5.2",
-    "chevrotain": "^10.1.2",
+    "chevrotain": "^11.0.3",
     "draco3d": "^1.4.1",
     "fflate": "^0.6.9",
     "ktx-parse": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
-    "*": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    },
+    "./*": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"

--- a/package.json
+++ b/package.json
@@ -19,9 +19,17 @@
   "homepage": "https://github.com/pmndrs/three-stdlib",
   "repository": "https://github.com/pmndrs/three-stdlib",
   "license": "MIT",
+  "type": "module",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
+  "exports": {
+    "*": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
   "sideEffects": false,
   "devDependencies": {
     "@types/three": "^0.128.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@types/three": "^0.128.0",
+    "chevrotain": "^11.0.3",
     "copyfiles": "^2.4.1",
     "json": "^11.0.0",
     "prettier": "^2.2.1",
@@ -37,7 +38,6 @@
     "@types/draco3d": "^1.4.0",
     "@types/offscreencanvas": "^2019.6.4",
     "@types/webxr": "^0.5.2",
-    "chevrotain": "^11.0.3",
     "draco3d": "^1.4.1",
     "fflate": "^0.6.9",
     "ktx-parse": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
   "repository": "https://github.com/pmndrs/three-stdlib",
   "license": "MIT",
   "type": "module",
-  "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "types": "./index.d.ts",
+  "main": "./index.cjs",
+  "module": "./index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "types": "./index.d.ts",
+      "require": "./index.cjs",
+      "import": "./index.js"
     },
     "./*": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "types": "./index.d.ts",
+      "require": "./index.cjs",
+      "import": "./index.js"
     }
   },
   "sideEffects": false,
@@ -63,7 +63,7 @@
     "three": ">=0.128.0"
   },
   "scripts": {
-    "build": "rimraf dist && vite build && tsc --emitDeclarationOnly && copyfiles -u 1 \"src/**/*.d.ts\" dist && copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=undefined; this.types=\\\"./index.d.ts\\\"; this.main=\\\"./index.cjs\\\"; this.module=\\\"./index.js\\\";\"",
+    "build": "rimraf dist && vite build && tsc --emitDeclarationOnly && copyfiles -u 1 \"src/**/*.d.ts\" dist && copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=undefined;\"",
     "lint": "tsc --noEmit"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
 import { defineConfig } from 'vite'
 
+const inline: string[] = ['chevrotain']
+
 export default defineConfig({
   build: {
     minify: false,
@@ -11,7 +13,7 @@ export default defineConfig({
       fileName: (format) => (format === 'es' ? '[name].js' : '[name].cjs'),
     },
     rollupOptions: {
-      external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id),
+      external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id) && !inline.includes(id),
       treeshake: false,
       output: { preserveModules: true },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
     rollupOptions: {
       external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id) && !inline.includes(id),
       treeshake: false,
-      output: { preserveModules: true },
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
     },
   },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
 import * as path from 'path'
 import { defineConfig } from 'vite'
 
-const inline: string[] = ['chevrotain']
+const inline: string[] = [
+  'chevrotain',
+  '@chevrotain/cst-dts-gen',
+  '@chevrotain/gast',
+  '@chevrotain/regexp-to-ast',
+  '@chevrotain/types',
+  '@chevrotain/utils',
+  'lodash-es',
+]
 
 export default defineConfig({
   build: {
@@ -14,11 +22,6 @@ export default defineConfig({
     },
     rollupOptions: {
       external: (id: string) => !id.startsWith('.') && !path.isAbsolute(id) && !inline.includes(id),
-      treeshake: false,
-      output: {
-        preserveModules: true,
-        preserveModulesRoot: 'src',
-      },
     },
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,32 +2,37 @@
 # yarn lockfile v1
 
 
-"@chevrotain/cst-dts-gen@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.1.2.tgz#4ee6eff237bb47f4990cfb76c18ee2e71237929c"
-  integrity sha512-E/XrL0QlzExycPzwhOEZGVOheJ/Clr5uNv3oCds88MiNqEmg3UU1iauZk7DhjsUo3jgEW4lf0I5HRl7/HC5ZkQ==
+"@chevrotain/cst-dts-gen@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz#5e0863cc57dc45e204ccfee6303225d15d9d4783"
+  integrity sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==
   dependencies:
-    "@chevrotain/gast" "^10.1.2"
-    "@chevrotain/types" "^10.1.2"
-    lodash "4.17.21"
+    "@chevrotain/gast" "11.0.3"
+    "@chevrotain/types" "11.0.3"
+    lodash-es "4.17.21"
 
-"@chevrotain/gast@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@chevrotain/gast/-/gast-10.1.2.tgz#91d5b342480d7532118a6cf3958955f86c9cc03e"
-  integrity sha512-er+TcxUOMuGOPoiOq8CJsRm92zGE4YPIYtyxJfxoVwVgtj4AMrPNCmrHvYaK/bsbt2DaDuFdcbbAfM9bcBXW6Q==
+"@chevrotain/gast@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/gast/-/gast-11.0.3.tgz#e84d8880323fe8cbe792ef69ce3ffd43a936e818"
+  integrity sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==
   dependencies:
-    "@chevrotain/types" "^10.1.2"
-    lodash "4.17.21"
+    "@chevrotain/types" "11.0.3"
+    lodash-es "4.17.21"
 
-"@chevrotain/types@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-10.1.2.tgz#f4caa373b1cd14d13ecb61c77dfee2456eef1ab3"
-  integrity sha512-4qF9SmmWKv8AIG/3d+71VFuqLumNCQTP5GoL0CW6x7Ay2OdXm6FUgWFLTMneGUjYUk2C+MSCf7etQfdq3LEr1A==
+"@chevrotain/regexp-to-ast@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz#11429a81c74a8e6a829271ce02fc66166d56dcdb"
+  integrity sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==
 
-"@chevrotain/utils@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@chevrotain/utils/-/utils-10.1.2.tgz#d2fb7b968141139e5c2419553e5295382c265e7d"
-  integrity sha512-bbZIpW6fdyf7FMaeDmw3cBbkTqsecxEkwlVKgVfqqXWBPLH6azxhPA2V9F7OhoZSVrsnMYw7QuyK6qutXPjEew==
+"@chevrotain/types@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.0.3.tgz#f8a03914f7b937f594f56eb89312b3b8f1c91848"
+  integrity sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==
+
+"@chevrotain/utils@11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chevrotain/utils/-/utils-11.0.3.tgz#e39999307b102cff3645ec4f5b3665f5297a2224"
+  integrity sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==
 
 "@esbuild/android-arm64@0.17.19":
   version "0.17.19"
@@ -184,17 +189,17 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-chevrotain@^10.1.2:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-10.1.2.tgz#c990ab43e32fd0bfb176ad1cbdebf48302ac8542"
-  integrity sha512-hvRiQuhhTZxkPMGD/dke+s1EGo8AkKDBU05CcufBO278qgAQSwIC4QyLdHz0CFHVtqVYWjlAS5D1KwvBbaHT+w==
+chevrotain@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-11.0.3.tgz#88ffc1fb4b5739c715807eaeedbbf200e202fc1b"
+  integrity sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==
   dependencies:
-    "@chevrotain/cst-dts-gen" "^10.1.2"
-    "@chevrotain/gast" "^10.1.2"
-    "@chevrotain/types" "^10.1.2"
-    "@chevrotain/utils" "^10.1.2"
-    lodash "4.17.21"
-    regexp-to-ast "0.5.0"
+    "@chevrotain/cst-dts-gen" "11.0.3"
+    "@chevrotain/gast" "11.0.3"
+    "@chevrotain/regexp-to-ast" "11.0.3"
+    "@chevrotain/types" "11.0.3"
+    "@chevrotain/utils" "11.0.3"
+    lodash-es "4.17.21"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -353,10 +358,10 @@ ktx-parse@^0.4.5:
   resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.4.5.tgz#79905e22281a9d3e602b2ff522df1ee7d1813aa6"
   integrity sha512-MK3FOody4TXbFf8Yqv7EBbySw7aPvEcPX++Ipt6Sox+/YMFvR5xaTyhfNSk1AEmMy+RYIw81ctN4IMxCB8OAlg==
 
-lodash@4.17.21:
+lodash-es@4.17.21:
   version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -459,11 +464,6 @@ readable-stream@~2.3.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-regexp-to-ast@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz#56c73856bee5e1fef7f73a00f1473452ab712a24"
-  integrity sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### Why

Came across [this issue](https://github.com/Chevrotain/chevrotain/issues/1643) while developing a new nextjs project. It seems like the bundler does't find a default export from api.js. Chevrotain 11 is pure ESM, so there are only named exports, which means it shouldn't look for a default export at all.

```
./node_modules/chevrotain/lib_esm/api_esm.mjs
Attempted import error: '../lib/src/api.js' does not contain a default export (imported as 'mod').

Import trace for requested module:
./node_modules/chevrotain/lib_esm/api_esm.mjs
./node_modules/three-stdlib/loaders/VRMLLoader.js
./node_modules/three-stdlib/index.js
./node_modules/@react-three/drei/web/Select.js
./node_modules/@react-three/drei/index.js
./components/Graphic.tsx
```

### What

Updated Chevrotain version to 11

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

