### PR TITLE
fix: Inline 'regexp-to-ast' dependency

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,10 @@ const inline: string[] = [
   'chevrotain',
   '@chevrotain/cst-dts-gen',
   '@chevrotain/gast',
-  '@chevrotain/regexp-to-ast',
   '@chevrotain/types',
   '@chevrotain/utils',
   'lodash-es',
+  'regexp-to-ast',
 ]
 
 export default defineConfig({


### PR DESCRIPTION
The `regexp-to-ast` must either be a production dependency, or inlined. I'm not sure I understand the tree-shaking implications of the last PR, or whether this should affect anything there.

Related:

- https://github.com/pmndrs/three-stdlib/pull/288
- https://github.com/pmndrs/three-stdlib/issues/287