### PR TITLE
fix(OrbitControls): make use of setPointerCapture

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -812,6 +812,8 @@ class OrbitControls extends EventDispatcher {
       if (scope.enabled === false) return
 
       if (pointers.length === 0) {
+        scope.domElement?.setPointerCapture(event.pointerId)
+        
         scope.domElement?.ownerDocument.addEventListener('pointermove', onPointerMove)
         scope.domElement?.ownerDocument.addEventListener('pointerup', onPointerUp)
       }

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -414,8 +414,8 @@ class OrbitControls extends EventDispatcher {
       scope.domElement?.removeEventListener('pointerdown', onPointerDown)
       scope.domElement?.removeEventListener('pointercancel', onPointerCancel)
       scope.domElement?.removeEventListener('wheel', onMouseWheel)
-      scope.domElement?.ownerDocument.removeEventListener('pointermove', onPointerMove)
-      scope.domElement?.ownerDocument.removeEventListener('pointerup', onPointerUp)
+      scope.domElement?.removeEventListener('pointermove', onPointerMove)
+      scope.domElement?.removeEventListener('pointerup', onPointerUp)
       if (scope._domElementKeyEvents !== null) {
         scope._domElementKeyEvents.removeEventListener('keydown', onKeyDown)
       }
@@ -813,9 +813,9 @@ class OrbitControls extends EventDispatcher {
 
       if (pointers.length === 0) {
         scope.domElement?.setPointerCapture(event.pointerId)
-        
-        scope.domElement?.ownerDocument.addEventListener('pointermove', onPointerMove)
-        scope.domElement?.ownerDocument.addEventListener('pointerup', onPointerUp)
+
+        scope.domElement?.addEventListener('pointermove', onPointerMove)
+        scope.domElement?.addEventListener('pointerup', onPointerUp)
       }
 
       addPointer(event)
@@ -843,8 +843,8 @@ class OrbitControls extends EventDispatcher {
       if (pointers.length === 0) {
         scope.domElement?.releasePointerCapture(event.pointerId)
 
-        scope.domElement?.ownerDocument.removeEventListener('pointermove', onPointerMove)
-        scope.domElement?.ownerDocument.removeEventListener('pointerup', onPointerUp)
+        scope.domElement?.removeEventListener('pointermove', onPointerMove)
+        scope.domElement?.removeEventListener('pointerup', onPointerUp)
       }
 
       scope.dispatchEvent(endEvent)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Orbit controls in three/examples has this line, it prevents text and other element selection on the screen when you drag camera. 

https://github.com/avaturn/three.js/blob/dev/examples/jsm/controls/OrbitControls.js#L979C4-L979C4

### What

Added the line

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

