### PR TITLE
Revert "fix(OrbitControls): make use of setPointerCapture"

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -414,8 +414,8 @@ class OrbitControls extends EventDispatcher {
       scope.domElement?.removeEventListener('pointerdown', onPointerDown)
       scope.domElement?.removeEventListener('pointercancel', onPointerCancel)
       scope.domElement?.removeEventListener('wheel', onMouseWheel)
-      scope.domElement?.removeEventListener('pointermove', onPointerMove)
-      scope.domElement?.removeEventListener('pointerup', onPointerUp)
+      scope.domElement?.ownerDocument.removeEventListener('pointermove', onPointerMove)
+      scope.domElement?.ownerDocument.removeEventListener('pointerup', onPointerUp)
       if (scope._domElementKeyEvents !== null) {
         scope._domElementKeyEvents.removeEventListener('keydown', onKeyDown)
       }
@@ -812,10 +812,8 @@ class OrbitControls extends EventDispatcher {
       if (scope.enabled === false) return
 
       if (pointers.length === 0) {
-        scope.domElement?.setPointerCapture(event.pointerId)
-
-        scope.domElement?.addEventListener('pointermove', onPointerMove)
-        scope.domElement?.addEventListener('pointerup', onPointerUp)
+        scope.domElement?.ownerDocument.addEventListener('pointermove', onPointerMove)
+        scope.domElement?.ownerDocument.addEventListener('pointerup', onPointerUp)
       }
 
       addPointer(event)
@@ -843,8 +841,8 @@ class OrbitControls extends EventDispatcher {
       if (pointers.length === 0) {
         scope.domElement?.releasePointerCapture(event.pointerId)
 
-        scope.domElement?.removeEventListener('pointermove', onPointerMove)
-        scope.domElement?.removeEventListener('pointerup', onPointerUp)
+        scope.domElement?.ownerDocument.removeEventListener('pointermove', onPointerMove)
+        scope.domElement?.ownerDocument.removeEventListener('pointerup', onPointerUp)
       }
 
       scope.dispatchEvent(endEvent)


### PR DESCRIPTION
This is a breaking change that causes the presence of OrbitControls to break pointer events, if desired it should be released in a major. 

An alternative to reverting is making this opt-in via init options

- Reverts https://github.com/pmndrs/three-stdlib/pull/297
- Issue https://github.com/pmndrs/drei/issues/1675