### PR TITLE
fix(OrbitControls): update lookAt when matrixAutoUpdate false

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -289,7 +289,7 @@ class OrbitControls extends EventDispatcher {
 
         position.copy(scope.target).add(offset)
 
-        if (!scope.object.matrixAutoUpdate) scope.object.updateMatrix();
+        if (!scope.object.matrixAutoUpdate) scope.object.updateMatrix()
         scope.object.lookAt(scope.target)
 
         if (scope.enableDamping === true) {

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -289,6 +289,7 @@ class OrbitControls extends EventDispatcher {
 
         position.copy(scope.target).add(offset)
 
+        if (!scope.object.matrixAutoUpdate) scope.object.updateMatrix();
         scope.object.lookAt(scope.target)
 
         if (scope.enableDamping === true) {


### PR DESCRIPTION
When `matrixAutoUpdate` is false, the `lookAt` does not get the correct matrix and the target is delayed. This PR calls a manual `matrixUpdate` if `matrixAutoUpdate` is false.