### PR TITLE
fix(types): remove references to Shader type

### DIFF
--- a/src/postprocessing/ShaderPass.ts
+++ b/src/postprocessing/ShaderPass.ts
@@ -1,13 +1,14 @@
-import { Shader, ShaderMaterial, UniformsUtils, WebGLRenderer, WebGLRenderTarget } from 'three'
+import { ShaderMaterial, UniformsUtils, WebGLRenderer, WebGLRenderTarget } from 'three'
 import { Pass, FullScreenQuad } from './Pass'
+import { Defines, IShader, Uniforms } from '../shaders/types'
 
 class ShaderPass extends Pass {
   public textureID: string
-  public uniforms: Shader['uniforms']
+  public uniforms: Uniforms
   public material: ShaderMaterial
   public fsQuad: FullScreenQuad
 
-  constructor(shader: ShaderMaterial | (Shader & { defines?: Object }), textureID = 'tDiffuse') {
+  constructor(shader: ShaderMaterial | IShader<Uniforms, Defines | undefined>, textureID = 'tDiffuse') {
     super()
 
     this.textureID = textureID

--- a/src/shaders/types.ts
+++ b/src/shaders/types.ts
@@ -1,9 +1,9 @@
-import type { IUniform, Shader } from 'three'
+import type { IUniform } from 'three'
 
-type Defines = { [key: string]: boolean | number | string }
-type Uniforms = { [key: string]: IUniform }
+export type Defines = { [key: string]: boolean | number | string }
+export type Uniforms = { [key: string]: IUniform }
 
-export interface IShader<U extends Uniforms, D extends Defines | undefined = undefined> extends Shader {
+export interface IShader<U extends Uniforms, D extends Defines | undefined = undefined> {
   defines?: D
   fragmentShader: string
   uniforms: U


### PR DESCRIPTION
### Why

The types have errors when used with @types/three@0.160.0, because [the `Shader` type was removed in @types/three@0.160.0](https://github.com/three-types/three-ts-types/releases/tag/r160) due it it being used in ways it wasn't intended to be used. The type errors are:

```
Error: ./node_modules/three-stdlib/postprocessing/ShaderPass.d.ts(1,10): error TS2305: Module '"three"' has no exported member 'Shader'.
Error: ./node_modules/three-stdlib/shaders/types.d.ts(1,25): error TS2305: Module '"three"' has no exported member 'Shader'.
```

### What

Remove use of the `Shader` type with more suitable types.

### Checklist

- [x] Ready to be merged
