### PR TITLE
fix(EXRLoader): support longname flag

### DIFF
--- a/src/loaders/EXRLoader.js
+++ b/src/loaders/EXRLoader.js
@@ -1655,7 +1655,8 @@ class EXRLoader extends DataTextureLoader {
         }
       }
 
-      if (spec != 0) {
+      if ((spec & ~0x04) != 0) {
+        // unsupported tiled, deep-image, multi-part
         console.error('EXRHeader:', EXRHeader)
         throw 'THREE.EXRLoader: provided file is currently unsupported.'
       }


### PR DESCRIPTION
Fixes #318. Mirrors https://github.com/mrdoob/three.js/pull/24049.