### PR TITLE
fix(HDRCubeTextureLoader): colorSpace <=> encoding fallback

### DIFF
--- a/src/loaders/HDRCubeTextureLoader.js
+++ b/src/loaders/HDRCubeTextureLoader.js
@@ -60,7 +60,7 @@ class HDRCubeTextureLoader extends Loader {
               const dataTexture = new DataTexture(texData.data, texData.width, texData.height)
 
               dataTexture.type = texture.type
-              dataTexture.encoding = texture.encoding
+              dataTexture.colorSpace = texture.SRGBColorSpace;
               dataTexture.format = texture.format
               dataTexture.minFilter = texture.minFilter
               dataTexture.magFilter = texture.magFilter

--- a/src/loaders/HDRCubeTextureLoader.js
+++ b/src/loaders/HDRCubeTextureLoader.js
@@ -60,7 +60,8 @@ class HDRCubeTextureLoader extends Loader {
               const dataTexture = new DataTexture(texData.data, texData.width, texData.height)
 
               dataTexture.type = texture.type
-              dataTexture.colorSpace = texture.SRGBColorSpace;
+              if ('colorSpace' in dataTexture) dataTexture.colorSpace = texture.SRGBColorSpace
+              else dataTexture.encoding = texture.encoding
               dataTexture.format = texture.format
               dataTexture.minFilter = texture.minFilter
               dataTexture.magFilter = texture.magFilter


### PR DESCRIPTION
### Why

According to three.js version 0.152 [migration guide](https://github.com/mrdoob/three.js/wiki/Migration-Guide), Texture.encoding has been replaced with Texture.colorSpace with THREE.NoColorSpace as the default value 

### What

Fixed warning logged in console "THREE.Texture: Property .encoding has been replaced by .colorSpace." 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
