### PR TITLE
fix(types): fix usages of ambient THREE namespace

### DIFF
--- a/src/animation/MMDPhysics.d.ts
+++ b/src/animation/MMDPhysics.d.ts
@@ -1,4 +1,4 @@
-import { Bone, Euler, Matrix4, Object3D, Quaternion, SkinnedMesh, Vector3 } from 'three'
+import { Bone, Euler, Matrix4, MeshBasicMaterial, Object3D, Quaternion, SkinnedMesh, Vector3 } from 'three'
 
 export interface MMDPhysicsParameter {
   unitStep?: number | undefined
@@ -110,10 +110,10 @@ export class Constraint {
 }
 
 export class MMDPhysicsHelper extends Object3D {
-  mesh: THREE.SkinnedMesh
+  mesh: SkinnedMesh
   physics: MMDPhysics
-  materials: [THREE.MeshBasicMaterial, THREE.MeshBasicMaterial, THREE.MeshBasicMaterial]
+  materials: [MeshBasicMaterial, MeshBasicMaterial, MeshBasicMaterial]
 
-  constructor(mesh: THREE.SkinnedMesh, physics: MMDPhysics)
+  constructor(mesh: SkinnedMesh, physics: MMDPhysics)
   dispose(): void
 }

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -274,10 +274,7 @@ class OrbitControls extends EventDispatcher {
 
         // adjust the camera position based on zoom only if we're not zooming to the cursor or if it's an ortho camera
         // we adjust zoom later in these cases
-        if (
-          (scope.zoomToCursor && performCursorZoom) ||
-          (scope.object as THREE.OrthographicCamera).isOrthographicCamera
-        ) {
+        if ((scope.zoomToCursor && performCursorZoom) || (scope.object as OrthographicCamera).isOrthographicCamera) {
           spherical.radius = clampDistance(spherical.radius)
         } else {
           spherical.radius = clampDistance(spherical.radius * scale)
@@ -317,7 +314,7 @@ class OrbitControls extends EventDispatcher {
             const radiusDelta = prevRadius - newRadius
             scope.object.position.addScaledVector(dollyDirection, radiusDelta)
             scope.object.updateMatrixWorld()
-          } else if ((scope.object as THREE.OrthographicCamera).isOrthographicCamera) {
+          } else if ((scope.object as OrthographicCamera).isOrthographicCamera) {
             // adjust the ortho camera position based on zoom changes
             const mouseBefore = new Vector3(mouse.x, mouse.y, 0)
             mouseBefore.unproject(scope.object)

--- a/src/utils/RoughnessMipmapper.d.ts
+++ b/src/utils/RoughnessMipmapper.d.ts
@@ -1,8 +1,8 @@
-import { WebGLRenderer } from 'three'
+import { Material, WebGLRenderer } from 'three'
 
 export class RoughnessMipmapper {
   constructor(renderer: WebGLRenderer)
 
-  generateMipmaps(material: THREE.Material): void
+  generateMipmaps(material: Material): void
   dispose(): void
 }


### PR DESCRIPTION
### Why

The ambient THREE namespace was [removed in `@types/three@0.162.0`](https://github.com/three-types/three-ts-types/releases/tag/r162).

### What

Removes usages of the ambient THREE namespace.

### Checklist

- [x] Ready to be merged
