### PR TITLE
fix(types): stub TextureEncoding

### DIFF
--- a/src/objects/Reflector.d.ts
+++ b/src/objects/Reflector.d.ts
@@ -1,4 +1,5 @@
-import { Mesh, BufferGeometry, Color, TextureEncoding, WebGLRenderTarget, PerspectiveCamera } from 'three'
+import { Mesh, BufferGeometry, Color, WebGLRenderTarget, PerspectiveCamera } from 'three'
+import { TextureEncoding } from '../types/shared'
 
 export interface ReflectorOptions {
   color?: Color | string | number

--- a/src/objects/Refractor.d.ts
+++ b/src/objects/Refractor.d.ts
@@ -1,4 +1,5 @@
-import { Mesh, BufferGeometry, Color, TextureEncoding, WebGLRenderTarget, PerspectiveCamera } from 'three'
+import { Mesh, BufferGeometry, Color, WebGLRenderTarget, PerspectiveCamera } from 'three'
+import { TextureEncoding } from '../types/shared'
 
 export interface RefractorOptions {
   color?: Color | string | number

--- a/src/objects/Water2.d.ts
+++ b/src/objects/Water2.d.ts
@@ -1,4 +1,5 @@
-import { BufferGeometry, Color, Mesh, ShaderMaterial, Texture, TextureEncoding, Vector2 } from 'three'
+import { BufferGeometry, Color, Mesh, ShaderMaterial, Texture, Vector2 } from 'three'
+import { TextureEncoding } from '../types/shared'
 
 export interface Water2Options {
   color?: Color | string | number

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -19,3 +19,10 @@ export type TypedArrayConstructors =
   | Uint32Array['constructor']
   | Float32Array['constructor']
   | Float64Array['constructor']
+
+type LinearEncoding = 3000
+type sRGBEncoding = 3001
+/**
+ * Stub for `TextureEncoding` type since it was removed in r162.
+ */
+export type TextureEncoding = LinearEncoding | sRGBEncoding


### PR DESCRIPTION
### Why

[`TextureEncoding` was removed in r162](https://github.com/three-types/three-ts-types/releases/tag/r162).

### What

Stub the `TextureEncoding` type to avoid a breaking change.

### Checklist

- [x] Ready to be merged
