### PR TITLE
fix(KTX2Loader): remove parse overload from types

### DIFF
--- a/src/loaders/KTX2Loader.d.ts
+++ b/src/loaders/KTX2Loader.d.ts
@@ -7,10 +7,4 @@ export class KTX2Loader extends CompressedTextureLoader {
   setWorkerLimit(limit: number): KTX2Loader
   detectSupport(renderer: WebGLRenderer): KTX2Loader
   dispose(): KTX2Loader
-
-  parse(
-    buffer: ArrayBuffer,
-    onLoad: (texture: CompressedTexture) => void,
-    onError?: (event: ErrorEvent) => void,
-  ): KTX2Loader
 }


### PR DESCRIPTION
### Why

resolves #345

### What

Removed the erroneous "parse" method from KTX2Loader.d.ts

### Checklist
- [x] Ready to be merged
