### PR TITLE
Fixed rotation defect in VRMLLoader.js

### DIFF
--- a/src/loaders/VRMLLoader.js
+++ b/src/loaders/VRMLLoader.js
@@ -719,7 +719,7 @@ class VRMLLoader extends Loader {
             break
 
           case 'rotation':
-            const axis = new Vector3(fieldValues[0], fieldValues[1], fieldValues[2])
+            const axis = new Vector3(fieldValues[0], fieldValues[1], fieldValues[2]).normalize()
             const angle = fieldValues[3]
             object.quaternion.setFromAxisAngle(axis, angle)
             break


### PR DESCRIPTION
### Why

Three.js AxisAngle apparently requires a normalized axis vector.  VRML may also, but I had many files (converted from VRML 1.0) that contained un-normalized axis vectors.

Whether there is a defect in my VRML data or not, normalization is idempotent and can only help.

### What

I added `.normalize()` to the axis vector for a rotation in VRMLLoader.js.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

