### PR TITLE
Enabling touchAction when `this.dispose` is called.

### DIFF
--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -414,7 +414,9 @@ class OrbitControls extends EventDispatcher {
 
     this.dispose = (): void => {
       // Enabling touch scroll
-      scope.domElement?.style.touchAction = 'auto'
+      if(scope.domElement) {
+        scope.domElement.style.touchAction = 'auto'
+      }
       scope.domElement?.removeEventListener('contextmenu', onContextMenu)
       scope.domElement?.removeEventListener('pointerdown', onPointerDown)
       scope.domElement?.removeEventListener('pointercancel', onPointerCancel)

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -413,6 +413,8 @@ class OrbitControls extends EventDispatcher {
     }
 
     this.dispose = (): void => {
+      // Enabling touch scroll
+      scope.domElement?.style.touchAction = 'auto'
       scope.domElement?.removeEventListener('contextmenu', onContextMenu)
       scope.domElement?.removeEventListener('pointerdown', onPointerDown)
       scope.domElement?.removeEventListener('pointercancel', onPointerCancel)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When connecting to the OrbitControl, we set `touchAction` to `none`, which prevents the user from scrolling the page and allows them to interact with the 3D scene. However, when we dispose of the OrbitControl, we don't re-enable the `touchAction`, which means the user is unable to scroll the page even after the OrbitControl is disabled or removed.

There are situations where we want to allow users to interact with the scene when they click a button, but in other cases, we don't want them to interact, and instead, allow them to scroll the page. However, if we set the `touchAction` to `none` and don't re-enable it after disposing of the OrbitControl, the user will be unable to scroll the page at all.

### What

<!-- what have you done, if its a bug, whats your solution? -->

In `this.dispose` method, I set `touchAction` to `auto`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
