### PR TITLE
fix(loaders): vendor decodeText for r165 deprecation

### DIFF
--- a/src/_polyfill/LoaderUtils.js
+++ b/src/_polyfill/LoaderUtils.js
@@ -1,0 +1,25 @@
+export function decodeText(array) {
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder().decode(array)
+  }
+
+  // Avoid the String.fromCharCode.apply(null, array) shortcut, which
+  // throws a "maximum call stack size exceeded" error for large arrays.
+
+  let s = ''
+
+  for (let i = 0, il = array.length; i < il; i++) {
+    // Implicitly assumes little-endian.
+    s += String.fromCharCode(array[i])
+  }
+
+  try {
+    // merges multi-byte utf-8 characters.
+
+    return decodeURIComponent(escape(s))
+  } catch (e) {
+    // see https://github.com/mrdoob/three.js/issues/16358
+
+    return s
+  }
+}

--- a/src/loaders/3MFLoader.js
+++ b/src/loaders/3MFLoader.js
@@ -20,6 +20,7 @@ import {
   TextureLoader,
 } from 'three'
 import { unzipSync } from 'fflate'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 /**
  *
@@ -121,14 +122,14 @@ class ThreeMFLoader extends Loader {
       //
 
       const relsView = zip[relsName]
-      const relsFileText = LoaderUtils.decodeText(relsView)
+      const relsFileText = decodeText(relsView)
       const rels = parseRelsXml(relsFileText)
 
       //
 
       if (modelRelsName) {
         const relsView = zip[modelRelsName]
-        const relsFileText = LoaderUtils.decodeText(relsView)
+        const relsFileText = decodeText(relsView)
         modelRels = parseRelsXml(relsFileText)
       }
 
@@ -138,7 +139,7 @@ class ThreeMFLoader extends Loader {
         const modelPart = modelPartNames[i]
         const view = zip[modelPart]
 
-        const fileText = LoaderUtils.decodeText(view)
+        const fileText = decodeText(view)
         const xmlData = new DOMParser().parseFromString(fileText, 'application/xml')
 
         if (xmlData.documentElement.nodeName.toLowerCase() !== 'model') {

--- a/src/loaders/AMFLoader.js
+++ b/src/loaders/AMFLoader.js
@@ -10,6 +10,7 @@ import {
   MeshPhongMaterial,
 } from 'three'
 import { unzipSync } from 'fflate'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 /**
  * Description: Early release of an AMF Loader following the pattern of the
@@ -90,7 +91,7 @@ class AMFLoader extends Loader {
         view = new DataView(zip[file].buffer)
       }
 
-      const fileText = LoaderUtils.decodeText(view)
+      const fileText = decodeText(view)
       const xmlData = new DOMParser().parseFromString(fileText, 'application/xml')
 
       if (xmlData.documentElement.nodeName.toLowerCase() !== 'amf') {

--- a/src/loaders/FBXLoader.js
+++ b/src/loaders/FBXLoader.js
@@ -42,6 +42,7 @@ import {
 } from 'three'
 import { unzlibSync } from 'fflate'
 import { NURBSCurve } from '../curves/NURBSCurve'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 /**
  * Loader loads FBX file and generates Group representing FBX scene.
@@ -3005,7 +3006,7 @@ class BinaryReader {
     const nullByte = a.indexOf(0)
     if (nullByte >= 0) a = a.slice(0, nullByte)
 
-    return LoaderUtils.decodeText(new Uint8Array(a))
+    return decodeText(new Uint8Array(a))
   }
 }
 
@@ -3268,7 +3269,7 @@ function convertArrayBufferToString(buffer, from, to) {
   if (from === undefined) from = 0
   if (to === undefined) to = buffer.byteLength
 
-  return LoaderUtils.decodeText(new Uint8Array(buffer, from, to))
+  return decodeText(new Uint8Array(buffer, from, to))
 }
 
 function append(a, b) {

--- a/src/loaders/GLTFLoader.js
+++ b/src/loaders/GLTFLoader.js
@@ -64,6 +64,7 @@ import {
 } from 'three'
 import { toTrianglesDrawMode } from '../utils/BufferGeometryUtils'
 import { version } from '../_polyfill/constants'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 const SRGBColorSpace = 'srgb'
 const LinearSRGBColorSpace = 'srgb-linear'
@@ -257,7 +258,7 @@ class GLTFLoader extends Loader {
     if (typeof data === 'string') {
       json = JSON.parse(data)
     } else if (data instanceof ArrayBuffer) {
-      const magic = LoaderUtils.decodeText(new Uint8Array(data.slice(0, 4)))
+      const magic = decodeText(new Uint8Array(data.slice(0, 4)))
 
       if (magic === BINARY_EXTENSION_HEADER_MAGIC) {
         try {
@@ -269,7 +270,7 @@ class GLTFLoader extends Loader {
 
         json = JSON.parse(extensions[EXTENSIONS.KHR_BINARY_GLTF].content)
       } else {
-        json = JSON.parse(LoaderUtils.decodeText(new Uint8Array(data)))
+        json = JSON.parse(decodeText(new Uint8Array(data)))
       }
     } else {
       json = data
@@ -1446,7 +1447,7 @@ class GLTFBinaryExtension {
     const headerView = new DataView(data, 0, BINARY_EXTENSION_HEADER_LENGTH)
 
     this.header = {
-      magic: LoaderUtils.decodeText(new Uint8Array(data.slice(0, 4))),
+      magic: decodeText(new Uint8Array(data.slice(0, 4))),
       version: headerView.getUint32(4, true),
       length: headerView.getUint32(8, true),
     }
@@ -1470,7 +1471,7 @@ class GLTFBinaryExtension {
 
       if (chunkType === BINARY_EXTENSION_CHUNK_TYPES.JSON) {
         const contentArray = new Uint8Array(data, BINARY_EXTENSION_HEADER_LENGTH + chunkIndex, chunkLength)
-        this.content = LoaderUtils.decodeText(contentArray)
+        this.content = decodeText(contentArray)
       } else if (chunkType === BINARY_EXTENSION_CHUNK_TYPES.BIN) {
         const byteOffset = BINARY_EXTENSION_HEADER_LENGTH + chunkIndex
         this.body = data.slice(byteOffset, byteOffset + chunkLength)

--- a/src/loaders/PCDLoader.js
+++ b/src/loaders/PCDLoader.js
@@ -1,4 +1,5 @@
 import { BufferGeometry, FileLoader, Float32BufferAttribute, Loader, LoaderUtils, Points, PointsMaterial } from 'three'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 class PCDLoader extends Loader {
   constructor(manager) {
@@ -158,7 +159,7 @@ class PCDLoader extends Loader {
       return PCDheader
     }
 
-    const textData = LoaderUtils.decodeText(new Uint8Array(data))
+    const textData = decodeText(new Uint8Array(data))
 
     // parse header (always ascii format)
 

--- a/src/loaders/PLYLoader.js
+++ b/src/loaders/PLYLoader.js
@@ -1,4 +1,5 @@
 import { BufferGeometry, FileLoader, Float32BufferAttribute, Loader, LoaderUtils } from 'three'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 /**
  * Description: A THREE loader for PLY ASCII files (known as the Polygon
@@ -421,7 +422,7 @@ class PLYLoader extends Loader {
     const scope = this
 
     if (data instanceof ArrayBuffer) {
-      const text = LoaderUtils.decodeText(new Uint8Array(data))
+      const text = decodeText(new Uint8Array(data))
       const header = parseHeader(text)
 
       geometry = header.format === 'ascii' ? parseASCII(text, header) : parseBinary(data, header)

--- a/src/loaders/STLLoader.js
+++ b/src/loaders/STLLoader.js
@@ -7,6 +7,7 @@ import {
   LoaderUtils,
   Vector3,
 } from 'three'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 /**
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.
@@ -305,7 +306,7 @@ class STLLoader extends Loader {
 
     function ensureString(buffer) {
       if (typeof buffer !== 'string') {
-        return LoaderUtils.decodeText(new Uint8Array(buffer))
+        return decodeText(new Uint8Array(buffer))
       }
 
       return buffer

--- a/src/loaders/VTKLoader.js
+++ b/src/loaders/VTKLoader.js
@@ -1,5 +1,6 @@
 import { BufferAttribute, BufferGeometry, FileLoader, Float32BufferAttribute, Loader, LoaderUtils } from 'three'
 import { unzlibSync } from 'fflate'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 class VTKLoader extends Loader {
   constructor(manager) {
@@ -885,12 +886,12 @@ class VTKLoader extends Loader {
     }
 
     // get the 5 first lines of the files to check if there is the key word binary
-    var meta = LoaderUtils.decodeText(new Uint8Array(data, 0, 250)).split('\n')
+    var meta = decodeText(new Uint8Array(data, 0, 250)).split('\n')
 
     if (meta[0].indexOf('xml') !== -1) {
-      return parseXML(LoaderUtils.decodeText(data))
+      return parseXML(decodeText(data))
     } else if (meta[2].includes('ASCII')) {
-      return parseASCII(LoaderUtils.decodeText(data))
+      return parseASCII(decodeText(data))
     } else {
       return parseBinary(data)
     }

--- a/src/loaders/XLoader.js
+++ b/src/loaders/XLoader.js
@@ -19,6 +19,7 @@ import {
   Vector2,
   Vector3,
 } from 'three'
+import { decodeText } from '../_polyfill/LoaderUtils'
 
 var XLoader = (function () {
   var classCallCheck = function (instance, Constructor) {
@@ -363,7 +364,7 @@ var XLoader = (function () {
         key: '_ensureString',
         value: function _ensureString(buf) {
           if (typeof buf !== 'string') {
-            return LoaderUtils.decodeText(new Uint8Array(buf))
+            return decodeText(new Uint8Array(buf))
           } else {
             return buf
           }
@@ -381,7 +382,7 @@ var XLoader = (function () {
       {
         key: '_parseBinary',
         value: function _parseBinary(data) {
-          return this._parseASCII(LoaderUtils.decodeText(new Uint8Array(data)))
+          return this._parseASCII(decodeText(new Uint8Array(data)))
         },
       },
       {


### PR DESCRIPTION
Vendors `LoaderUtils.decodeText` with the deprecation of https://github.com/mrdoob/three.js/pull/28278.

We use this over `TextDecoder` to play nice with Node, react-native, and edge environments where browser APIs are limited.