### PR TITLE
fix(KTX2Loader): web worker scope

### DIFF
--- a/src/loaders/KTX2Loader.js
+++ b/src/loaders/KTX2Loader.js
@@ -129,9 +129,12 @@ class KTX2Loader extends Loader {
     let transcoderPending
     let BasisModule
 
-    const EngineFormat = KTX2Loader.EngineFormat
-    const TranscoderFormat = KTX2Loader.TranscoderFormat
-    const BasisFormat = KTX2Loader.BasisFormat
+    /** @type KTX2Loader.EngineFormat */
+    const EngineFormat = _EngineFormat
+    /** @type KTX2Loader.TranscoderFormat */
+    const TranscoderFormat = _TranscoderFormat
+    /** @type KTX2Loader.BasisFormat */
+    const BasisFormat = _BasisFormat
 
     self.addEventListener('message', function (e) {
       const message = e.data


### PR DESCRIPTION
### Why

The web workers created by KTX2Loader throw the following error: `Uncaught ReferenceError: _KTX2Loader is not defined`.
This PR fixes that.

### What

Updated the `BasisWorker` function to reference the variables that are prepended to the web worker code instead of referencing these values from the `KTX2Loader` class.

Although the `BasisWorker` function is defined within the `KTX2Loader` class, once it's stringified and used as code for a web worker it doesn't have access anymore to its original upper scope. Therefore it will throw an `ReferenceError`.

JSDoc type annotations have been added to get the right type hinting in the `BasisWorker` code.

### Checklist

- [x] Ready to be merged

Fixes:
- https://github.com/pmndrs/drei/issues/1860
