### PR TITLE
fix(types): compatibility with @types/three@0.167.0

### DIFF
--- a/src/deprecated/Geometry.d.ts
+++ b/src/deprecated/Geometry.d.ts
@@ -7,7 +7,6 @@ import {
   Sphere,
   Matrix4,
   BufferGeometry,
-  Matrix,
   Mesh,
   Bone,
   AnimationClip,
@@ -232,7 +231,7 @@ export class Geometry extends EventDispatcher {
    */
   computeBoundingSphere(): void
 
-  merge(geometry: Geometry, matrix?: Matrix, materialIndexOffset?: number): void
+  merge(geometry: Geometry, matrix?: Matrix4, materialIndexOffset?: number): void
 
   mergeMesh(mesh: Mesh): void
 


### PR DESCRIPTION
### Why

The `Matrix` interface was removed in [@types/three@0.167.0](https://github.com/three-types/three-ts-types/releases/tag/r167). `Matrix4` seems like the better type anyway.

### What

Replace use of `Matrix` interface with `Matrix4`.

### Checklist

- [x] Ready to be merged
