### PR TITLE
fix: BufferGeometry rename uv2 to uv1

### DIFF
--- a/src/_polyfill/uv1.ts
+++ b/src/_polyfill/uv1.ts
@@ -1,0 +1,7 @@
+import { version } from "./constants";
+
+/** uv2 renamed to uv1 in r125
+ * 
+ * https://github.com/mrdoob/three.js/pull/25943
+*/
+export const UV1 = version >= 125 ? 'uv1' : 'uv2'

--- a/src/exporters/ColladaExporter.ts
+++ b/src/exporters/ColladaExporter.ts
@@ -14,6 +14,7 @@ import {
   Texture,
 } from 'three'
 import type { TypedArray, TypedArrayConstructors } from '../types/shared'
+import { UV1 } from '../_polyfill/uv1'
 
 /**
  * https://github.com/gkjohnson/collada-exporter-js
@@ -346,9 +347,9 @@ class ColladaExporter {
       }
 
       // serialize lightmap uvs
-      if ('uv1' in bufferGeometry.attributes) {
+      if (UV1 in bufferGeometry.attributes) {
         const uvName = `${meshid}-texcoord2`
-        gnode += this.getAttribute(bufferGeometry.attributes.uv1, uvName, ['S', 'T'], 'float')
+        gnode += this.getAttribute(bufferGeometry.attributes[UV1], uvName, ['S', 'T'], 'float')
         triangleInputs += `<input semantic="TEXCOORD" source="#${uvName}" offset="0" set="1" />`
       }
 

--- a/src/exporters/ColladaExporter.ts
+++ b/src/exporters/ColladaExporter.ts
@@ -346,9 +346,9 @@ class ColladaExporter {
       }
 
       // serialize lightmap uvs
-      if ('uv2' in bufferGeometry.attributes) {
+      if ('uv1' in bufferGeometry.attributes) {
         const uvName = `${meshid}-texcoord2`
-        gnode += this.getAttribute(bufferGeometry.attributes.uv2, uvName, ['S', 'T'], 'float')
+        gnode += this.getAttribute(bufferGeometry.attributes.uv1, uvName, ['S', 'T'], 'float')
         triangleInputs += `<input semantic="TEXCOORD" source="#${uvName}" offset="0" set="1" />`
       }
 

--- a/src/lines/LineSegments2.js
+++ b/src/lines/LineSegments2.js
@@ -12,6 +12,7 @@ import {
 } from 'three'
 import { LineSegmentsGeometry } from '../lines/LineSegmentsGeometry'
 import { LineMaterial } from '../lines/LineMaterial'
+import { UV1 } from '../_polyfill/uv1'
 
 const _start = new Vector3()
 const _end = new Vector3()
@@ -67,7 +68,7 @@ function raycastWorldUnits(lineSegments, intersects) {
         face: null,
         faceIndex: i,
         uv: null,
-        uv1: null,
+        [UV1]: null,
       })
     }
   }
@@ -187,7 +188,7 @@ function raycastScreenSpace(lineSegments, camera, intersects) {
         face: null,
         faceIndex: i,
         uv: null,
-        uv1: null,
+        [UV1]: null,
       })
     }
   }

--- a/src/lines/LineSegments2.js
+++ b/src/lines/LineSegments2.js
@@ -67,7 +67,7 @@ function raycastWorldUnits(lineSegments, intersects) {
         face: null,
         faceIndex: i,
         uv: null,
-        uv2: null,
+        uv1: null,
       })
     }
   }
@@ -187,7 +187,7 @@ function raycastScreenSpace(lineSegments, camera, intersects) {
         face: null,
         faceIndex: i,
         uv: null,
-        uv2: null,
+        uv1: null,
       })
     }
   }

--- a/src/loaders/ColladaLoader.js
+++ b/src/loaders/ColladaLoader.js
@@ -39,6 +39,7 @@ import {
   VectorKeyframeTrack,
 } from 'three'
 import { TGALoader } from '../loaders/TGALoader'
+import { UV1 } from '../_polyfill/uv1'
 
 class ColladaLoader extends Loader {
   constructor(manager) {
@@ -2025,7 +2026,7 @@ class ColladaLoader extends Loader {
       }
       if (color.array.length > 0) geometry.setAttribute('color', new Float32BufferAttribute(color.array, color.stride))
       if (uv.array.length > 0) geometry.setAttribute('uv', new Float32BufferAttribute(uv.array, uv.stride))
-      if (uv1.array.length > 0) geometry.setAttribute('uv1', new Float32BufferAttribute(uv1.array, uv1.stride))
+      if (uv1.array.length > 0) geometry.setAttribute(UV1, new Float32BufferAttribute(uv1.array, uv1.stride))
 
       if (skinIndex.array.length > 0) {
         geometry.setAttribute('skinIndex', new Float32BufferAttribute(skinIndex.array, skinIndex.stride))

--- a/src/loaders/ColladaLoader.js
+++ b/src/loaders/ColladaLoader.js
@@ -1866,7 +1866,7 @@ class ColladaLoader extends Loader {
       const position = { array: [], stride: 0 }
       const normal = { array: [], stride: 0 }
       const uv = { array: [], stride: 0 }
-      const uv2 = { array: [], stride: 0 }
+      const uv1 = { array: [], stride: 0 }
       const color = { array: [], stride: 0 }
 
       const skinIndex = { array: [], stride: 4 }
@@ -1981,7 +1981,7 @@ class ColladaLoader extends Loader {
                     break
 
                   case 'TEXCOORD1':
-                    buildGeometryData(primitive, sources[id], input.offset, uv2.array)
+                    buildGeometryData(primitive, sources[id], input.offset, uv1.array)
                     uv.stride = sources[id].stride
                     break
 
@@ -2008,8 +2008,8 @@ class ColladaLoader extends Loader {
               break
 
             case 'TEXCOORD1':
-              buildGeometryData(primitive, sources[input.id], input.offset, uv2.array)
-              uv2.stride = sources[input.id].stride
+              buildGeometryData(primitive, sources[input.id], input.offset, uv1.array)
+              uv1.stride = sources[input.id].stride
               break
           }
         }
@@ -2025,7 +2025,7 @@ class ColladaLoader extends Loader {
       }
       if (color.array.length > 0) geometry.setAttribute('color', new Float32BufferAttribute(color.array, color.stride))
       if (uv.array.length > 0) geometry.setAttribute('uv', new Float32BufferAttribute(uv.array, uv.stride))
-      if (uv2.array.length > 0) geometry.setAttribute('uv2', new Float32BufferAttribute(uv2.array, uv2.stride))
+      if (uv1.array.length > 0) geometry.setAttribute('uv1', new Float32BufferAttribute(uv1.array, uv1.stride))
 
       if (skinIndex.array.length > 0) {
         geometry.setAttribute('skinIndex', new Float32BufferAttribute(skinIndex.array, skinIndex.stride))
@@ -2496,14 +2496,14 @@ class ColladaLoader extends Loader {
             if (value > joint.limits.max || value < joint.limits.min) {
               console.warn(
                 'THREE.ColladaLoader: Joint ' +
-                  jointIndex +
-                  ' value ' +
-                  value +
-                  ' outside of limits (min: ' +
-                  joint.limits.min +
-                  ', max: ' +
-                  joint.limits.max +
-                  ').',
+                jointIndex +
+                ' value ' +
+                value +
+                ' outside of limits (min: ' +
+                joint.limits.min +
+                ', max: ' +
+                joint.limits.max +
+                ').',
               )
             } else if (joint.static) {
               console.warn('THREE.ColladaLoader: Joint ' + jointIndex + ' is static.')

--- a/src/loaders/FBXLoader.js
+++ b/src/loaders/FBXLoader.js
@@ -43,6 +43,7 @@ import {
 import { unzlibSync } from 'fflate'
 import { NURBSCurve } from '../curves/NURBSCurve'
 import { decodeText } from '../_polyfill/LoaderUtils'
+import { UV1 } from '../_polyfill/uv1'
 
 /**
  * Loader loads FBX file and generates Group representing FBX scene.
@@ -1274,6 +1275,7 @@ class GeometryParser {
     }
 
     buffers.uvs.forEach(function (uvBuffer, i) {
+      if (UV1 === 'uv2') i++;
       const name = i === 0 ? 'uv' : `uv${i}`;
 
       geo.setAttribute(name, new Float32BufferAttribute(buffers.uvs[i], 2))

--- a/src/loaders/FBXLoader.js
+++ b/src/loaders/FBXLoader.js
@@ -1274,13 +1274,7 @@ class GeometryParser {
     }
 
     buffers.uvs.forEach(function (uvBuffer, i) {
-      // subsequent uv buffers are called 'uv1', 'uv2', ...
-      let name = 'uv' + (i + 1).toString()
-
-      // the first uv buffer is just called 'uv'
-      if (i === 0) {
-        name = 'uv'
-      }
+      const name = i === 0 ? 'uv' : `uv${i}`;
 
       geo.setAttribute(name, new Float32BufferAttribute(buffers.uvs[i], 2))
     })

--- a/src/loaders/LWOLoader.js
+++ b/src/loaders/LWOLoader.js
@@ -148,8 +148,6 @@ class LWOTreeParser {
 
     const materials = this.getMaterials(geometry.userData.matNames, layer.geometry.type)
 
-    this.duplicateUVs(geometry, materials)
-
     if (layer.geometry.type === 'points') mesh = new Points(geometry, materials)
     else if (layer.geometry.type === 'lines') mesh = new LineSegments(geometry, materials)
     else mesh = new Mesh(geometry, materials)
@@ -221,23 +219,6 @@ class LWOTreeParser {
     return this.materials.filter(function (m) {
       return m.name === name
     })[0]
-  }
-
-  // If the material has an aoMap, duplicate UVs
-  duplicateUVs(geometry, materials) {
-    let duplicateUVs = false
-
-    if (!Array.isArray(materials)) {
-      if (materials.aoMap) duplicateUVs = true
-    } else {
-      materials.forEach(function (material) {
-        if (material.aoMap) duplicateUVs = true
-      })
-    }
-
-    if (!duplicateUVs) return
-
-    geometry.setAttribute('uv2', new BufferAttribute(geometry.attributes.uv.array, 2))
   }
 }
 

--- a/src/loaders/LWOLoader.js
+++ b/src/loaders/LWOLoader.js
@@ -40,6 +40,7 @@ import {
 } from 'three'
 
 import { IFFParser } from './lwo/IFFParser.js'
+import { UV1 } from '../_polyfill/uv1.ts'
 
 let _lwoTree
 
@@ -148,6 +149,8 @@ class LWOTreeParser {
 
     const materials = this.getMaterials(geometry.userData.matNames, layer.geometry.type)
 
+    if (UV1 === 'uv2') this.duplicateUVs(geometry, materials)
+
     if (layer.geometry.type === 'points') mesh = new Points(geometry, materials)
     else if (layer.geometry.type === 'lines') mesh = new LineSegments(geometry, materials)
     else mesh = new Mesh(geometry, materials)
@@ -219,6 +222,23 @@ class LWOTreeParser {
     return this.materials.filter(function (m) {
       return m.name === name
     })[0]
+  }
+
+  // If the material has an aoMap, duplicate UVs
+  duplicateUVs(geometry, materials) {
+    let duplicateUVs = false
+
+    if (!Array.isArray(materials)) {
+      if (materials.aoMap) duplicateUVs = true
+    } else {
+      materials.forEach(function (material) {
+        if (material.aoMap) duplicateUVs = true
+      })
+    }
+
+    if (!duplicateUVs) return
+
+    geometry.setAttribute('uv2', new BufferAttribute(geometry.attributes.uv.array, 2))
   }
 }
 

--- a/src/misc/ProgressiveLightmap.js
+++ b/src/misc/ProgressiveLightmap.js
@@ -9,6 +9,7 @@ import {
   Mesh,
 } from 'three'
 import potpack from 'potpack'
+import { UV1 } from '../_polyfill/uv1'
 
 /**
  * Progressive Light Map Accumulator, by [zalo](https://github.com/zalo/)
@@ -52,16 +53,16 @@ class ProgressiveLightMap {
       shader.vertexShader =
         '#define USE_LIGHTMAP\n' +
         shader.vertexShader.slice(0, -1) +
-        '	gl_Position = vec4((uv1 - 0.5) * 2.0, 1.0, 1.0); }'
+        `	gl_Position = vec4((${UV1} - 0.5) * 2.0, 1.0, 1.0); }`
 
       // Fragment Shader: Set Pixels to average in the Previous frame's Shadows
       const bodyStart = shader.fragmentShader.indexOf('void main() {')
       shader.fragmentShader =
-        'varying vec2 vuv1;\n' +
+        `varying vec2 v${UV1 === 'uv1' ? UV1 : 'Uv2'};\n` +
         shader.fragmentShader.slice(0, bodyStart) +
         '	uniform sampler2D previousShadowMap;\n	uniform float averagingWindow;\n' +
         shader.fragmentShader.slice(bodyStart - 1, -1) +
-        `\nvec3 texelOld = texture2D(previousShadowMap, vuv1).rgb;
+        `\nvec3 texelOld = texture2D(previousShadowMap, v${UV1 === 'uv1' ? UV1 : 'Uv2'}).rgb;
 				gl_FragColor.rgb = mix(texelOld, gl_FragColor.rgb, 1.0/averagingWindow);
 			}`
 
@@ -130,8 +131,8 @@ class ProgressiveLightMap {
         uv1.array[i + 1] = (uv1.array[i + 1] + box.y + padding) / dimensions.h
       }
 
-      objects[box.index].geometry.setAttribute('uv1', uv1)
-      objects[box.index].geometry.getAttribute('uv1').needsUpdate = true
+      objects[box.index].geometry.setAttribute(UV1, uv1)
+      objects[box.index].geometry.getAttribute(UV1).needsUpdate = true
     })
   }
 

--- a/src/misc/ProgressiveLightmap.js
+++ b/src/misc/ProgressiveLightmap.js
@@ -52,16 +52,16 @@ class ProgressiveLightMap {
       shader.vertexShader =
         '#define USE_LIGHTMAP\n' +
         shader.vertexShader.slice(0, -1) +
-        '	gl_Position = vec4((uv2 - 0.5) * 2.0, 1.0, 1.0); }'
+        '	gl_Position = vec4((uv1 - 0.5) * 2.0, 1.0, 1.0); }'
 
       // Fragment Shader: Set Pixels to average in the Previous frame's Shadows
       const bodyStart = shader.fragmentShader.indexOf('void main() {')
       shader.fragmentShader =
-        'varying vec2 vUv2;\n' +
+        'varying vec2 vuv1;\n' +
         shader.fragmentShader.slice(0, bodyStart) +
         '	uniform sampler2D previousShadowMap;\n	uniform float averagingWindow;\n' +
         shader.fragmentShader.slice(bodyStart - 1, -1) +
-        `\nvec3 texelOld = texture2D(previousShadowMap, vUv2).rgb;
+        `\nvec3 texelOld = texture2D(previousShadowMap, vuv1).rgb;
 				gl_FragColor.rgb = mix(texelOld, gl_FragColor.rgb, 1.0/averagingWindow);
 			}`
 
@@ -79,7 +79,7 @@ class ProgressiveLightMap {
   }
 
   /**
-   * Sets these objects' materials' lightmaps and modifies their uv2's.
+   * Sets these objects' materials' lightmaps and modifies their uv1's.
    * @param {Object3D} objects An array of objects and lights to set up your lightmap.
    */
   addObjectsToLightMap(objects) {
@@ -124,14 +124,14 @@ class ProgressiveLightMap {
     // Pack the objects' lightmap UVs into the same global space
     const dimensions = potpack(this.uv_boxes)
     this.uv_boxes.forEach((box) => {
-      const uv2 = objects[box.index].geometry.getAttribute('uv').clone()
-      for (let i = 0; i < uv2.array.length; i += uv2.itemSize) {
-        uv2.array[i] = (uv2.array[i] + box.x + padding) / dimensions.w
-        uv2.array[i + 1] = (uv2.array[i + 1] + box.y + padding) / dimensions.h
+      const uv1 = objects[box.index].geometry.getAttribute('uv').clone()
+      for (let i = 0; i < uv1.array.length; i += uv1.itemSize) {
+        uv1.array[i] = (uv1.array[i] + box.x + padding) / dimensions.w
+        uv1.array[i + 1] = (uv1.array[i + 1] + box.y + padding) / dimensions.h
       }
 
-      objects[box.index].geometry.setAttribute('uv2', uv2)
-      objects[box.index].geometry.getAttribute('uv2').needsUpdate = true
+      objects[box.index].geometry.setAttribute('uv1', uv1)
+      objects[box.index].geometry.getAttribute('uv1').needsUpdate = true
     })
   }
 

--- a/src/modifiers/TessellateModifier.ts
+++ b/src/modifiers/TessellateModifier.ts
@@ -1,4 +1,5 @@
 import { BufferGeometry, Color, Float32BufferAttribute, Vector2, Vector3 } from 'three'
+import { UV1 } from '../_polyfill/uv1'
 
 /**
  * Break faces with edges longer than maxEdgeLength
@@ -57,7 +58,7 @@ class TessellateModifier {
     const hasNormals = attributes.normal !== undefined
     const hasColors = attributes.color !== undefined
     const hasUVs = attributes.uv !== undefined
-    const hasUV1s = attributes.uv1 !== undefined
+    const hasUV1s = attributes[UV1] !== undefined
 
     let positions = attributes.position.array
     let normals = hasNormals ? attributes.normal.array : null
@@ -238,7 +239,7 @@ class TessellateModifier {
     }
 
     if (hasUV1s) {
-      geometry2.setAttribute('uv1', new Float32BufferAttribute(uv1s2 as any, 2))
+      geometry2.setAttribute(UV1, new Float32BufferAttribute(uv1s2 as any, 2))
     }
 
     return geometry2

--- a/src/modifiers/TessellateModifier.ts
+++ b/src/modifiers/TessellateModifier.ts
@@ -57,19 +57,19 @@ class TessellateModifier {
     const hasNormals = attributes.normal !== undefined
     const hasColors = attributes.color !== undefined
     const hasUVs = attributes.uv !== undefined
-    const hasUV2s = attributes.uv2 !== undefined
+    const hasUV1s = attributes.uv1 !== undefined
 
     let positions = attributes.position.array
     let normals = hasNormals ? attributes.normal.array : null
     let colors = hasColors ? attributes.color.array : null
     let uvs = hasUVs ? attributes.uv.array : null
-    let uv2s = hasUV2s ? attributes.uv2.array : null
+    let uv1s = hasUV1s ? attributes.uv1.array : null
 
     let positions2 = (positions as unknown) as number[]
     let normals2 = (normals as unknown) as number[]
     let colors2 = (colors as unknown) as number[]
     let uvs2 = (uvs as unknown) as number[]
-    let uv2s2 = (uv2s as unknown) as number[]
+    let uv1s2 = (uv1s as unknown) as number[]
 
     let iteration = 0
     let tessellating = true
@@ -113,14 +113,14 @@ class TessellateModifier {
         uvs2.push(u3.x, u3.y)
       }
 
-      if (hasUV2s) {
+      if (hasUV1s) {
         const u21 = u2s[a]
         const u22 = u2s[b]
         const u23 = u2s[c]
 
-        uv2s2.push(u21.x, u21.y)
-        uv2s2.push(u22.x, u22.y)
-        uv2s2.push(u23.x, u23.y)
+        uv1s2.push(u21.x, u21.y)
+        uv1s2.push(u22.x, u22.y)
+        uv1s2.push(u23.x, u23.y)
       }
     }
 
@@ -146,9 +146,9 @@ class TessellateModifier {
         uvs2 = []
       }
 
-      if (hasUV2s) {
-        uv2s = uv2s2 as any
-        uv2s2 = []
+      if (hasUV1s) {
+        uv1s = uv1s2 as any
+        uv1s2 = []
       }
 
       for (let i = 0, i2 = 0, il = positions.length; i < il; i += 9, i2 += 6) {
@@ -174,10 +174,10 @@ class TessellateModifier {
           uc.fromArray(uvs, i2 + 4)
         }
 
-        if (hasUV2s && uv2s) {
-          u2a.fromArray(uv2s, i2 + 0)
-          u2b.fromArray(uv2s, i2 + 2)
-          u2c.fromArray(uv2s, i2 + 4)
+        if (hasUV1s && uv1s) {
+          u2a.fromArray(uv1s, i2 + 0)
+          u2b.fromArray(uv1s, i2 + 2)
+          u2c.fromArray(uv1s, i2 + 4)
         }
 
         const dab = va.distanceToSquared(vb)
@@ -192,7 +192,7 @@ class TessellateModifier {
             if (hasNormals) nm.lerpVectors(na, nb, 0.5)
             if (hasColors) cm.lerpColors(ca, cb, 0.5)
             if (hasUVs) um.lerpVectors(ua, ub, 0.5)
-            if (hasUV2s) u2m.lerpVectors(u2a, u2b, 0.5)
+            if (hasUV1s) u2m.lerpVectors(u2a, u2b, 0.5)
 
             addTriangle(0, 3, 2)
             addTriangle(3, 1, 2)
@@ -201,7 +201,7 @@ class TessellateModifier {
             if (hasNormals) nm.lerpVectors(nb, nc, 0.5)
             if (hasColors) cm.lerpColors(cb, cc, 0.5)
             if (hasUVs) um.lerpVectors(ub, uc, 0.5)
-            if (hasUV2s) u2m.lerpVectors(u2b, u2c, 0.5)
+            if (hasUV1s) u2m.lerpVectors(u2b, u2c, 0.5)
 
             addTriangle(0, 1, 3)
             addTriangle(3, 2, 0)
@@ -210,7 +210,7 @@ class TessellateModifier {
             if (hasNormals) nm.lerpVectors(na, nc, 0.5)
             if (hasColors) cm.lerpColors(ca, cc, 0.5)
             if (hasUVs) um.lerpVectors(ua, uc, 0.5)
-            if (hasUV2s) u2m.lerpVectors(u2a, u2c, 0.5)
+            if (hasUV1s) u2m.lerpVectors(u2a, u2c, 0.5)
 
             addTriangle(0, 1, 3)
             addTriangle(3, 1, 2)
@@ -237,8 +237,8 @@ class TessellateModifier {
       geometry2.setAttribute('uv', new Float32BufferAttribute(uvs2 as any, 2))
     }
 
-    if (hasUV2s) {
-      geometry2.setAttribute('uv2', new Float32BufferAttribute(uv2s2 as any, 2))
+    if (hasUV1s) {
+      geometry2.setAttribute('uv1', new Float32BufferAttribute(uv1s2 as any, 2))
     }
 
     return geometry2


### PR DESCRIPTION
`uv2` has been renamed to `uv1` in `threejs`: https://github.com/mrdoob/three.js/pull/25943
