### PR TITLE
fix: Add support for sRGBTransferOETF to fix the runtime error `'LinearTosRGB' : no matching overloaded function found`

### DIFF
--- a/src/shaders/GammaCorrectionShader.ts
+++ b/src/shaders/GammaCorrectionShader.ts
@@ -37,7 +37,11 @@ export const GammaCorrectionShader: IGammaCorrectionShader = {
 
     '	vec4 tex = texture2D( tDiffuse, vUv );',
 
-    '	gl_FragColor = LinearTosRGB( tex );',
+    '	#ifdef LinearTosRGB',
+    '		gl_FragColor = LinearTosRGB( tex );',
+    '	#else',
+    '		gl_FragColor = sRGBTransferOETF( tex );',
+    '	#endif',
 
     '}',
   ].join('\n'),


### PR DESCRIPTION
Add support for sRGBTransferOETF to fix the runtime error below.

```
THREE.WebGLProgram: Shader Error 0 - VALIDATE_STATUS false

Material Name: 
Material Type: ShaderMaterial

Program Info Log: Fragment shader is not compiled.


FRAGMENT

ERROR: 0:173: 'LinearTosRGB' : no matching overloaded function found
ERROR: 0:173: '=' : dimension mismatch
ERROR: 0:173: 'assign' : cannot convert from 'const mediump float' to 'out highp 4-component vector of float'


  168: 
  169: uniform sampler2D tDiffuse;
  170: varying vec2 vUv;
  171: void main() {
  172: 	vec4 tex = texture2D( tDiffuse, vUv );
> 173: 	gl_FragColor = LinearTosRGB( tex );
  174: }
```