### PR TITLE
fix: type compatibility with @types/three@0.172.0

### DIFF
--- a/src/postprocessing/Pass.ts
+++ b/src/postprocessing/Pass.ts
@@ -1,4 +1,4 @@
-import { OrthographicCamera, PlaneGeometry, Mesh, Material, Renderer, WebGLRenderer, WebGLRenderTarget } from 'three'
+import { OrthographicCamera, PlaneGeometry, Mesh, Material, WebGLRenderer, WebGLRenderTarget } from 'three'
 
 class Pass {
   // if set to true, the pass is processed by the composer
@@ -50,7 +50,7 @@ class FullScreenQuad<TMaterial extends Material = Material> {
     this.mesh.geometry.dispose()
   }
 
-  public render(renderer: Renderer): void {
+  public render(renderer: WebGLRenderer): void {
     renderer.render(this.mesh, this.camera)
   }
 }

--- a/src/utils/ShadowMapViewer.d.ts
+++ b/src/utils/ShadowMapViewer.d.ts
@@ -1,4 +1,4 @@
-import { Light, Renderer } from 'three'
+import { Light, WebGLRenderer } from 'three'
 
 export interface Size {
   width: number
@@ -18,7 +18,7 @@ export class ShadowMapViewer {
   enabled: boolean
   size: Size
   position: Position
-  render(renderer: Renderer): void
+  render(renderer: WebGLRenderer): void
   updateForWindowResize(): void
   update(): void
 }


### PR DESCRIPTION
### Why

The `Renderer` interface [was removed](https://github.com/three-types/three-ts-types/pull/1487) in [@types/three@0.172.0](https://github.com/three-types/three-ts-types/releases/tag/r172). This PR removes usages so that `three-stdlib` works with @types/three@0.172.0.

### What

Replace uses of `Renderer` with `WebGLRenderer`.

### Checklist

- [x] Documentation updated N/A
- [x] Storybook entry added N/A
- [x] Ready to be merged
