### PR TITLE
fix: error when used on server side via SVGRenderer

### DIFF
--- a/src/libs/lottie.js
+++ b/src/libs/lottie.js
@@ -1,5 +1,5 @@
 const lottie = /* @__PURE__ */ (() => {
-  if (typeof navigator === 'undefined' || typeof document === 'undefined') return {}
+  if (typeof navigator === 'undefined' || typeof document === 'undefined' || typeof CanvasRenderingContext2D === "undefined") return {}
 
   const svgNS = 'http://www.w3.org/2000/svg'
 

--- a/src/libs/lottie.js
+++ b/src/libs/lottie.js
@@ -1175,7 +1175,15 @@ const lottie = /* @__PURE__ */ (() => {
   })()
 
   const ImagePreloader = (function () {
-    var proxyImage
+    var proxyImage = (function () {
+      var canvas = createTag('canvas')
+      canvas.width = 1
+      canvas.height = 1
+      var ctx = canvas.getContext('2d')
+      ctx.fillStyle = 'rgba(0,0,0,0)'
+      ctx.fillRect(0, 0, 1, 1)
+      return canvas
+    })()
 
     function imageLoaded() {
       this.loadedAssets += 1
@@ -1356,15 +1364,6 @@ const lottie = /* @__PURE__ */ (() => {
     }
 
     function ImagePreloaderFactory() {
-      proxyImage = (function () {
-        var canvas = createTag('canvas')
-        canvas.width = 1
-        canvas.height = 1
-        var ctx = canvas.getContext('2d')
-        ctx.fillStyle = 'rgba(0,0,0,0)'
-        ctx.fillRect(0, 0, 1, 1)
-        return canvas
-      })()
       this._imageLoaded = imageLoaded.bind(this)
       this._footageLoaded = footageLoaded.bind(this)
       this.testImageLoaded = testImageLoaded.bind(this)

--- a/src/libs/lottie.js
+++ b/src/libs/lottie.js
@@ -1,5 +1,10 @@
 const lottie = /* @__PURE__ */ (() => {
-  if (typeof navigator === 'undefined' || typeof document === 'undefined' || typeof CanvasRenderingContext2D === "undefined") return {}
+  if (
+    typeof navigator === 'undefined' ||
+    typeof document === 'undefined' ||
+    typeof CanvasRenderingContext2D === 'undefined'
+  )
+    return {}
 
   const svgNS = 'http://www.w3.org/2000/svg'
 

--- a/src/libs/lottie.js
+++ b/src/libs/lottie.js
@@ -1175,15 +1175,7 @@ const lottie = /* @__PURE__ */ (() => {
   })()
 
   const ImagePreloader = (function () {
-    var proxyImage = (function () {
-      var canvas = createTag('canvas')
-      canvas.width = 1
-      canvas.height = 1
-      var ctx = canvas.getContext('2d')
-      ctx.fillStyle = 'rgba(0,0,0,0)'
-      ctx.fillRect(0, 0, 1, 1)
-      return canvas
-    })()
+    var proxyImage
 
     function imageLoaded() {
       this.loadedAssets += 1
@@ -1364,6 +1356,15 @@ const lottie = /* @__PURE__ */ (() => {
     }
 
     function ImagePreloaderFactory() {
+      proxyImage = (function () {
+        var canvas = createTag('canvas')
+        canvas.width = 1
+        canvas.height = 1
+        var ctx = canvas.getContext('2d')
+        ctx.fillStyle = 'rgba(0,0,0,0)'
+        ctx.fillRect(0, 0, 1, 1)
+        return canvas
+      })()
       this._imageLoaded = imageLoaded.bind(this)
       this._footageLoaded = footageLoaded.bind(this)
       this.testImageLoaded = testImageLoaded.bind(this)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When used on server side or test runner (without any bundling), it cause this kind of error even though I'm using SVGRenderer instead of the default renderer.

```js
   Error: 
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1052:7)
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1054:14)
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1248:12)
        at /home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:13924:10
  1047 |     var proxyImage = function() {
  1048 |       var canvas = createTag("canvas");
  1049 |       canvas.width = 1;
  1050 |       canvas.height = 1;
  1051 |       var ctx = canvas.getContext("2d");
  1052 |       ctx.fillStyle = "rgba(0,0,0,0)";
               ^
  TypeError: null is not an object (evaluating 'ctx.fillStyle = "rgba(0,0,0,0)"')
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1052:7)
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1054:14)
        at <anonymous> (/home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:1248:12)
        at /home/runner/work/circuit-to-svg/circuit-to-svg/node_modules/three-stdlib/libs/lottie.js:13924:10
```

### What

<!-- what have you done, if its a bug, whats your solution? -->
The problem cause by context2d being accessed eagerly in IIFE. It shouldn't be a problem to defer it at instantiation.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
