### PR TITLE
fix `export * type` to `export type *` in patch-ts

### DIFF
--- a/patch-ts.js
+++ b/patch-ts.js
@@ -7,7 +7,7 @@ for (const file of files) {
   const cts = file.replace('.d.ts', '.d.cts')
 
   // Add type qualifiers in annotations
-  shell.sed('-i', /(import|export [*{])\s+(?!type\b)/, '$1 type ', file)
+  shell.sed('-i', /(import|export )*\s+(?!type\b)/, '$1 type ', file)
   // Remove .js extensions
   shell.sed('-i', /from '(\.[^.]+)\.js'/, "from '$1'", file)
 


### PR DESCRIPTION
### Why

Bug introduced in #343, which was a fix for #342.

Closes #399

### What

Fix incorrect dist syntax from `export * type from` -> `export type * from`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->


/cc @bundyfx @CodyJasonBennett 

I'd prefer @CodyJasonBennett review