### PR TITLE
fix: Fix alignment of integer vertex attributes

### DIFF
--- a/src/exporters/GLTFExporter.js
+++ b/src/exporters/GLTFExporter.js
@@ -1024,7 +1024,13 @@ class GLTFWriter {
         componentSize = 4
     }
 
-    const byteLength = getPaddedBufferSize(count * attribute.itemSize * componentSize)
+    let byteStride = attribute.itemSize * componentSize
+    if (target === WEBGL_CONSTANTS.ARRAY_BUFFER) {
+      // Each element of a vertex attribute MUST be aligned to 4-byte boundaries
+      // inside a bufferView
+      byteStride = Math.ceil(byteStride / 4) * 4
+    }
+    const byteLength = getPaddedBufferSize(count * byteStride)
     const dataView = new DataView(new ArrayBuffer(byteLength))
     let offset = 0
 
@@ -1065,6 +1071,9 @@ class GLTFWriter {
 
         offset += componentSize
       }
+      if (offset % byteStride !== 0) {
+        offset += byteStride - (offset % byteStride)
+      }
     }
 
     const bufferViewDef = {
@@ -1077,7 +1086,7 @@ class GLTFWriter {
 
     if (target === WEBGL_CONSTANTS.ARRAY_BUFFER) {
       // Only define byteStride for vertex attributes.
-      bufferViewDef.byteStride = attribute.itemSize * componentSize
+      bufferViewDef.byteStride = byteStride
     }
 
     this.byteOffset += byteLength


### PR DESCRIPTION
### Why

resolves #407 

### What

syncing [this fix](https://github.com/mrdoob/three.js/commit/a7712cc3a0902f2c45e919a811622ed72ad5f5de) into the library's current implementation. And after local testing, it works fine.

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged
