### PR TITLE
Fix OBJExporter error on THREE.Line<BufferGeometry>

### DIFF
--- a/src/exporters/OBJExporter.ts
+++ b/src/exporters/OBJExporter.ts
@@ -168,7 +168,7 @@ class OBJExporter {
     const geometry = line.geometry
     const type = line.type
 
-    if (geometry.isBufferGeometry) {
+    if (!geometry.isBufferGeometry) {
       throw new Error('THREE.OBJExporter: Geometry is not of type THREE.BufferGeometry.')
     }
 


### PR DESCRIPTION
### Why

I negated an if so that if a `THREE.Line` object that is passed to the exporter and it has a geometry of type `BufferGeometry` the exporter does not throw an error. 

Issue #412 

### What

I negated the condition.

### Checklist

- [ ] Documentation updated (I don't think it's relevant)
- [ ] Storybook entry added  (apologies I can not find it)
- [ x] Ready to be merged
