### PR TITLE
fix: remove use of WebGL1 LuminanceFormat

### DIFF
--- a/src/postprocessing/GlitchPass.ts
+++ b/src/postprocessing/GlitchPass.ts
@@ -4,7 +4,6 @@ import {
   FloatType,
   MathUtils,
   RedFormat,
-  LuminanceFormat,
   ShaderMaterial,
   UniformsUtils,
   WebGLRenderTarget,
@@ -45,8 +44,6 @@ class GlitchPass extends Pass {
     readBuffer: WebGLRenderTarget,
     /*, deltaTime, maskActive */
   ): void {
-    if (renderer.capabilities.isWebGL2 === false) this.uniforms['tDisp'].value.format = LuminanceFormat
-
     this.uniforms['tDiffuse'].value = readBuffer.texture
     this.uniforms['seed'].value = Math.random() //default seeding
     this.uniforms['byp'].value = 0

--- a/src/postprocessing/SSAOPass.js
+++ b/src/postprocessing/SSAOPass.js
@@ -12,7 +12,6 @@ import {
   NearestFilter,
   NoBlending,
   RedFormat,
-  LuminanceFormat,
   DepthStencilFormat,
   UnsignedInt248Type,
   RepeatWrapping,
@@ -185,8 +184,6 @@ const SSAOPass = /* @__PURE__ */ (() => {
     }
 
     render(renderer, writeBuffer /*, readBuffer, deltaTime, maskActive */) {
-      if (renderer.capabilities.isWebGL2 === false) this.noiseTexture.format = LuminanceFormat
-
       // render beauty
 
       renderer.setRenderTarget(this.beautyRenderTarget)


### PR DESCRIPTION
Closes #418 with the removal of `LuminanceFormat` since https://github.com/mrdoob/three.js/pull/30934.