### PR TITLE
:heavy_plus_sign: Add static friction to orbit controls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "homepage": "https://github.com/pmndrs/three-stdlib",
   "repository": "https://github.com/pmndrs/three-stdlib",
   "license": "MIT",
-  "types": "./index.d.ts",
-  "main": "./index.cjs",
-  "module": "./index.js",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
-    "types": "./index.d.ts",
-    "require": "./index.cjs",
-    "import": "./index.js"
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.js"
   },
   "sideEffects": false,
   "devDependencies": {

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -52,6 +52,14 @@ class OrbitControls extends EventDispatcher<StandardControlsEventMap> {
   // If damping is enabled, you must call controls.update() in your animation loop
   enableDamping = false
   dampingFactor = 0.05
+  /**
+   * The static friction force applied to the movement.
+   * This is a constant force that opposes movement, independent of speed.
+   *
+   * @type {number}
+   * @default 0
+   */
+  staticMovingFriction = 0
   // This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
   // Set to false to disable zooming
   enableZoom = true
@@ -307,6 +315,33 @@ class OrbitControls extends EventDispatcher<StandardControlsEventMap> {
           sphericalDelta.phi *= 1 - scope.dampingFactor
 
           panOffset.multiplyScalar(1 - scope.dampingFactor)
+
+          if (scope.staticMovingFriction > 0) {
+            const thetaSign = Math.sign(sphericalDelta.theta)
+            if (thetaSign !== 0) {
+              sphericalDelta.theta -= thetaSign * scope.staticMovingFriction
+              if (Math.sign(sphericalDelta.theta) !== thetaSign) {
+                sphericalDelta.theta = 0
+              }
+            }
+
+            const phiSign = Math.sign(sphericalDelta.phi)
+            if (phiSign !== 0) {
+              sphericalDelta.phi -= phiSign * scope.staticMovingFriction
+              if (Math.sign(sphericalDelta.phi) !== phiSign) {
+                sphericalDelta.phi = 0
+              }
+            }
+
+            const panLen = panOffset.length()
+            if (panLen > 0) {
+              if (panLen > scope.staticMovingFriction) {
+                panOffset.multiplyScalar((panLen - scope.staticMovingFriction) / panLen)
+              } else {
+                panOffset.set(0, 0, 0)
+              }
+            }
+          }
         } else {
           sphericalDelta.set(0, 0, 0)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The orbit controls, when damping is used, behave in a way that the deceleration is excessively long and would tend to infinite if it weren't for the arithmetic precision limitation.

This situation makes comparing the speed to 0 a lengthy process. 

### What

<!-- what have you done, if its a bug, whats your solution? -->
The solution is to add a static friction parameter that always opposes the movement with fixed configurable strength. This guarantees that the coasting is much more consistent when damping is enabled.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Documentation updated
- [X] Storybook entry added
- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
