### PR TITLE
fix: dispose variable ShaderMaterials in GPUComputationRenderer.dispose()

### DIFF
--- a/src/misc/GPUComputationRenderer.js
+++ b/src/misc/GPUComputationRenderer.js
@@ -279,6 +279,8 @@ class GPUComputationRenderer {
           const renderTarget = renderTargets[j]
           renderTarget.dispose()
         }
+
+        variable.material.dispose()
       }
     }
 


### PR DESCRIPTION
## Summary

`GPUComputationRenderer.dispose()` disposes render targets and the pass-through shader material (`mesh.material`), but never disposes the `ShaderMaterial` instances created for each computation variable.

These materials are allocated in `createShaderMaterial()` (called from `addVariable()`) and stored on `variable.material`, but `dispose()` only calls `mesh.material.dispose()` — which is the `passThruShader`, not the per-variable materials. The variable `ShaderMaterial` objects and their associated WebGL programs are never released.

## Fix

One line: `variable.material.dispose()` inside the existing variable loop.

## How I found this

I work on a project that uses `GPUComputationRenderer` for a GPU-computed wave simulation. The app has a router that creates and destroys renderer instances on navigation. After switching between views repeatedly, GPU memory climbed steadily — the undisposed variable `ShaderMaterial` objects were accumulating.