### PR TITLE
fix: replace deprecated Clock with Timer

### DIFF
--- a/src/objects/Water2.js
+++ b/src/objects/Water2.js
@@ -1,5 +1,5 @@
 import {
-  Clock,
+  Timer,
   Color,
   Matrix4,
   Mesh,
@@ -190,7 +190,7 @@ const Water2 = /* @__PURE__ */ (() => {
       const cycle = 0.15 // a cycle of a flow map phase
       const halfCycle = cycle * 0.5
       const textureMatrix = new Matrix4()
-      const clock = new Clock()
+      const timer = new Timer()
 
       // internal components
 
@@ -278,7 +278,7 @@ const Water2 = /* @__PURE__ */ (() => {
       }
 
       function updateFlow() {
-        const delta = clock.getDelta()
+        const delta = timer.getDelta()
         const config = scope.material.uniforms['config']
 
         config.value.x += flowSpeed * delta // flowMapOffset0
@@ -299,6 +299,7 @@ const Water2 = /* @__PURE__ */ (() => {
       //
 
       this.onBeforeRender = function (renderer, scene, camera) {
+        timer.update()
         updateTextureMatrix(camera)
         updateFlow()
 

--- a/src/postprocessing/EffectComposer.ts
+++ b/src/postprocessing/EffectComposer.ts
@@ -1,4 +1,4 @@
-import { Clock, LinearFilter, RGBAFormat, NoBlending, Vector2, WebGLRenderer, WebGLRenderTarget } from 'three'
+import { Timer, LinearFilter, RGBAFormat, NoBlending, Vector2, WebGLRenderer, WebGLRenderTarget } from 'three'
 import { CopyShader } from '../shaders/CopyShader'
 import { ShaderPass } from './ShaderPass'
 import { MaskPass, ClearMaskPass } from './MaskPass'
@@ -16,7 +16,7 @@ class EffectComposer<TRenderTarget extends WebGLRenderTarget = WebGLRenderTarget
   public renderToScreen: boolean
   public passes: Pass[] = []
   public copyPass: Pass
-  public clock: Clock
+  public timer: Timer
 
   constructor(renderer: WebGLRenderer, renderTarget?: TRenderTarget) {
     this.renderer = renderer
@@ -68,7 +68,7 @@ class EffectComposer<TRenderTarget extends WebGLRenderTarget = WebGLRenderTarget
     // @ts-ignore
     this.copyPass.material.blending = NoBlending
 
-    this.clock = new Clock()
+    this.timer = new Timer()
   }
 
   public swapBuffers(): void {
@@ -108,8 +108,10 @@ class EffectComposer<TRenderTarget extends WebGLRenderTarget = WebGLRenderTarget
   public render(deltaTime?: number): void {
     // deltaTime value is in seconds
 
+    this.timer.update()
+
     if (deltaTime === undefined) {
-      deltaTime = this.clock.getDelta()
+      deltaTime = this.timer.getDelta()
     }
 
     const currentRenderTarget = this.renderer.getRenderTarget()


### PR DESCRIPTION
## Summary

- Replace `THREE.Clock` with `THREE.Timer` in `EffectComposer` and `Water2`
- Add required `timer.update()` calls before `getDelta()`
- Port of upstream mrdoob/three.js#32793

## Test plan

- [ ] Verify EffectComposer renders post-processing passes with correct frame timing
- [ ] Verify Water2 flow animation runs at correct speed
- [ ] Confirm no `THREE.Clock` deprecation warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)